### PR TITLE
added Field#path as full dot-notation path

### DIFF
--- a/lib/field-collection.js
+++ b/lib/field-collection.js
@@ -31,8 +31,10 @@ var FieldCollection = Collection.extend(lodashMixin, parentMixin, {
     // get or create field
     var field = this.get(name);
     if (!field) {
+      var path = this.parent && this.parent.path ? this.parent.path + '.' + name : name;
       field = this.add({
         name: name,
+        path: path,
         parent: this.parent
       });
       if (this.parent) {

--- a/lib/field.js
+++ b/lib/field.js
@@ -17,6 +17,14 @@ module.exports = State.extend({
       required: true
     },
     /**
+     * The full path in dot-notation, e.g. "address.street"
+     */
+    path: {
+      type: 'string',
+      required: true,
+      default: null
+    },
+    /**
      * Number of times this field has been seen in a sample of documents.
      */
     count: {

--- a/lib/type-collection.js
+++ b/lib/type-collection.js
@@ -66,14 +66,15 @@ module.exports = Collection.extend(lodashMixin, parentMixin, {
    */
   addToType: function(value) {
     var field = this.parent;
-
+    var path = this.parent ? this.parent.path : null;
     var typeName = getTypeName(value);
     var added = false;
     // get or create type
     var type = this.get(typeName);
     if (!type) {
       type = this.add({
-        name: typeName
+        name: typeName,
+        path: path
       });
       added = true;
     }

--- a/lib/types/type.js
+++ b/lib/types/type.js
@@ -16,7 +16,8 @@ var Type = AmpersandState.extend({
     }
   },
   session: {
-    parent: 'state'
+    parent: 'state',
+    path: 'string'
   },
   derived: {
     modelType: {

--- a/test/basic-embedded-document-array.test.js
+++ b/test/basic-embedded-document-array.test.js
@@ -25,5 +25,9 @@ describe('basic embedded document array', function() {
       following.toJSON();
     });
   });
+
+  it('should pass path down through array type', function() {
+    assert.equal(following.fields.get('following').arrayFields.at(0).path, 'following._id');
+  });
   // @todo: write more tests when not so tired...
 });

--- a/test/basic-embedded-documents.test.js
+++ b/test/basic-embedded-documents.test.js
@@ -35,7 +35,7 @@ describe('basic embedded documents', function() {
     users = getSchema('users', docs, done);
   });
 
-  it('should detect all fields', function() {
+  it('should detect all fields names and nested paths', function() {
     var field_names = [
       '_id',
       'created_at',
@@ -46,7 +46,14 @@ describe('basic embedded documents', function() {
       'stats',
       'twitter'
     ];
+
+    var nested_path_names = [
+      'push_token.android',
+      'push_token.apple'
+    ];
+
     assert.deepEqual(users.fields.pluck('name'), field_names);
+    assert.deepEqual(users.fields.get('push_token').fields.pluck('path'), nested_path_names);
   });
   it('should serialize correctly', function() {
     assert.doesNotThrow(function() {

--- a/test/nested-document-path.test.js
+++ b/test/nested-document-path.test.js
@@ -1,0 +1,25 @@
+var getSchema = require('../');
+var assert = require('assert');
+var BSON = require('bson');
+
+/*eslint new-cap: 0, quote-props: 0*/
+describe('nested document path', function() {
+  var schema;
+  var docs = [
+    {
+      'foo': {
+        'bar': {
+          'baz': 1
+        }
+      }
+    }
+  ];
+
+  before(function(done) {
+    schema = getSchema('nested.documents', docs, done);
+  });
+
+  it('should assemble the path correctly with dot-notation', function() {
+    assert.equal(schema.fields.get('foo').fields.get('bar').fields.get('baz').path, 'foo.bar.baz');
+  });
+});


### PR DESCRIPTION
```
{
  name: "Thomas",
  address: {
    street: "Park St",
    no: 16,
    postcode: 12345,
    city: "Sydney"
  },
  current_mood: "enthusiastic"
}
```

`Field#name` only contains the local name, e.g. `street` in above example. It is useful to also be able to access the full path in dot-notation, e.g. `address.street`. 

This change adds `Field#path` and is automatically set on document parsing.

Also added tests to verify.

