### PR TITLE
INT-1243 minicharts 1000

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -120,7 +120,7 @@ module.exports = State.extend({
     has_duplicates: {
       cache: false,
       fn: function() {
-        return this.unique < this.count;
+        return _.any(this.types.pluck('has_duplicates'));
       }
     },
     /**

--- a/lib/parse-native.js
+++ b/lib/parse-native.js
@@ -49,7 +49,8 @@ var addToType = function(path, value, schema) {
       addToField(path + '.' + k, v, type.fields);
     });
   } else {
-    type.values = _.get(type, 'values', new Reservoir(100));
+    type.values = _.get(type, 'values', type.name === 'String' ?
+      new Reservoir(100) : new Reservoir(10000));
     // if (type.values.length < 100) {
     //   type.values.push(value);
     // }

--- a/lib/types/constant.js
+++ b/lib/types/constant.js
@@ -12,6 +12,12 @@ var ConstantType = Type.extend({
         // more than 1 constant value means no longer unique
         return Math.min(this.count, 1);
       }
+    },
+    has_duplicates: {
+      deps: ['count'],
+      fn: function() {
+        return this.count > 1;
+      }
     }
   },
   parse: function(attrs) {

--- a/lib/types/primitive.js
+++ b/lib/types/primitive.js
@@ -19,6 +19,12 @@ var PrimitiveType = exports.PrimitiveType = Type.extend({
       fn: function() {
         return _.unique(this.values.pluck('value')).length;
       }
+    },
+    has_duplicates: {
+      cache: false,
+      fn: function() {
+        return this.unique < this.values.length;
+      }
     }
   },
   collections: {

--- a/lib/types/type.js
+++ b/lib/types/type.js
@@ -23,8 +23,16 @@ var Type = AmpersandState.extend({
   },
   session: {
     parent: 'state'
+    // unique: 'number'
+    // has_duplicates: 'boolean'
   },
   derived: {
+    has_duplicates: {
+      cache: false,
+      fn: function() {
+        return false;
+      }
+    },
     modelType: {
       fn: function() {
         return this.name;

--- a/test/basic-unique.test.js
+++ b/test/basic-unique.test.js
@@ -1,5 +1,37 @@
 var getSchema = require('../');
 var assert = require('assert');
+var _ = require('lodash');
+
+describe('has_duplicates', function() {
+  var docs = _.map(_.range(11111), function(val) {
+    return {
+      num: val,
+      str: String(val)
+    };
+  });
+
+  var schema;
+  before(function(done) {
+    schema = getSchema('has_duplicates', docs, function(err) {
+      if (err) {
+        return done(err);
+      }
+      done();
+    });
+  });
+
+  it('should not have duplicates', function() {
+    assert.equal(schema.fields.get('num').has_duplicates, false);
+  });
+
+  it('should have 100 number values for the `num` field', function() {
+    assert.equal(schema.fields.get('num').types.get('Number').values.length, 100);
+  });
+
+  it('should have 100 string values for the `str` field', function() {
+    assert.equal(schema.fields.get('str').types.get('String').values.length, 100);
+  });
+});
 
 describe('unique', function() {
   var docs = [

--- a/test/basic-unique.test.js
+++ b/test/basic-unique.test.js
@@ -24,8 +24,8 @@ describe('has_duplicates', function() {
     assert.equal(schema.fields.get('num').has_duplicates, false);
   });
 
-  it('should have 100 number values for the `num` field', function() {
-    assert.equal(schema.fields.get('num').types.get('Number').values.length, 100);
+  it('should have 10000 number values for the `num` field', function() {
+    assert.equal(schema.fields.get('num').types.get('Number').values.length, 10000);
   });
 
   it('should have 100 string values for the `str` field', function() {


### PR DESCRIPTION
- store 10,000 numeric values, but only 100 strings
- add `has_duplicates` on a type level, propagate up to field level
- added tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/mongodb-schema/30)
<!-- Reviewable:end -->
