### PR TITLE
avoid premature exit when piping to stdout

### DIFF
--- a/bin/mongodb-schema.js
+++ b/bin/mongodb-schema.js
@@ -173,6 +173,5 @@ mongodb.connect(uri, function(err, conn) {
       console.error('schema depth: ' + schema.depth);
     }
     conn.close();
-    process.exit(0);
   });
 });


### PR DESCRIPTION
I found that with the `process.exit(0)` call, the pipe to stdout gets destroyed prematurely before the next process in the pipe has all the data. 

For example: 

```
mongodb-schema localhost:27017 test.foo | morelikethis | mgeneratejs -n 100
```

The script `morelikethis` would not get the full schema output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/mongodb-schema/33)
<!-- Reviewable:end -->
