### PR TITLE
INT-1487 don’t use _.each to iterate over objects + test

### DIFF
--- a/lib/parse-native.js
+++ b/lib/parse-native.js
@@ -55,7 +55,7 @@ var addToType = function(path, value, schema) {
     });
   } else if (typeName === 'Document') {
     type.fields = _.get(type, 'fields', {});
-    _.each(value, function(v, k) {
+    _.forOwn(value, function(v, k) {
       addToField(path + '.' + k, v, type.fields);
     });
   } else {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,7 +17,8 @@ describe('using only basic fields', function() {
       'android_push_token': undefined,
       'last_address_latitude': null,
       'last_address_longitude': null,
-      'created_at': new Date()
+      'created_at': new Date(),
+      'length': 29
     }
   ];
 
@@ -37,6 +38,7 @@ describe('using only basic fields', function() {
       'is_verified',
       'last_address_latitude',
       'last_address_longitude',
+      'length',
       'name',
       'stats_friends',
       'twitter_username'
@@ -50,6 +52,7 @@ describe('using only basic fields', function() {
     assert.equal(users.fields.get('created_at').type, 'Date');
     assert.equal(users.fields.get('email').type, 'String');
     assert.equal(users.fields.get('is_verified').type, 'Boolean');
+    assert.equal(users.fields.get('length').type, 'Number');
     assert.equal(users.fields.get('last_address_latitude').type, 'Null');
     assert.equal(users.fields.get('last_address_longitude').type, 'Null');
     assert.equal(users.fields.get('name').type, 'String');


### PR DESCRIPTION
a lodash collection simply duck-type checks for the presence of a field `.length`.


Note: This doesn't actually fix the bug, these changes are just a precaution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/mongodb-schema/34)
<!-- Reviewable:end -->
