### PR TITLE
Added semantic type detection feature and ability to disable value storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ mongodb-schema mongodb://localhost:27017 mongodb.fanclub
 
 Additional arguments change the number of samples (`--sample`), print additional statistics about the
 schema analysis (`--stats`), switch to a different output format (`--format`), or let you suppress the
-schema output altogether (`--no-output`) if you are only interested in the schema statistics.
+schema output altogether (`--no-output`) if you are only interested in the schema statistics, semantic
+type discovery (`--semantic-types`), and the ability to disable value collection (`--no-values`).
 
 For more information, run
 
@@ -160,6 +161,25 @@ A high-level view of the schema tree structure is as follows:
 `mongodb-schema` supports all [BSON types][bson-types].
 Checkout [the tests][tests] for more usage examples.
 
+## Semantic Types
+
+As of version 6.1.0, mongodb-schema has a new feature called "Semantic Type Detection". It allows to override the type identification of a value. The only built-in detector is GeoJSON currently, which traditionally would just be detected as "Document" type. With the new option `semanticTypes` enabled, these sub-documents are now considered atomic values with a type "GeoJSON". The original BSON type name is still available under the `bsonType` field.
+
+To enable this mode, use the `-t` or `--semantic-types` flag at the command line. When using the API, pass an option object as the second parameter with the `semanticTypes` flag set to `true`:
+
+```javascript
+parseSchema(db.collection('data').find(), {semanticTypes: true}, function(err, schema) {
+  ...
+});
+```
+
+This mode is disabled by default.
+
+## Value Sampling
+
+As of version 6.1.0, mongodb-schema supports analysing only the structure of the documents, without collection data samples. To enable this mode, use the `--no-values` flag at the command line. When using the API, pass an option object as the second parameter with the `storeValues` flag set to `false`.
+
+This mode is enabled by default.
 
 ## Schema Statistics
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ Checkout [the tests][tests] for more usage examples.
 
 ## Semantic Types
 
-As of version 6.1.0, mongodb-schema has a new feature called "Semantic Type Detection". It allows to override the type identification of a value. The only built-in detector is GeoJSON currently, which traditionally would just be detected as "Document" type. With the new option `semanticTypes` enabled, these sub-documents are now considered atomic values with a type "GeoJSON". The original BSON type name is still available under the `bsonType` field.
+As of version 6.1.0, mongodb-schema has a new feature called "Semantic Type Detection". It allows to override the type identification of a value. This enables users to provide specific domain knowledge of their data, while still using
+the underlying flexible BSON representation and nested documents and arrays.
+
+One of the built-in semantic types is GeoJSON, which traditionally would just be detected as "Document" type. With the new option `semanticTypes` enabled, these sub-documents are now considered atomic values with a type "GeoJSON". The original BSON type name is still available under the `bsonType` field.
 
 To enable this mode, use the `-t` or `--semantic-types` flag at the command line. When using the API, pass an option object as the second parameter with the `semanticTypes` flag set to `true`:
 
@@ -172,8 +175,53 @@ parseSchema(db.collection('data').find(), {semanticTypes: true}, function(err, s
   ...
 });
 ```
-
 This mode is disabled by default.
+
+#### Custom Semantic Types
+
+It is also possible to provide custom semantic type detector functions. This is useful to provide domain
+knowledge, for example to detect trees or graphs, special string encodings of data, etc.
+
+The detector function is called with `value` and `path` (the full field path in dot notation)
+as arguments, and must return a truthy value if the data type applies to this field or value.
+
+Here is an example to detect email addresses:
+
+```javascript
+
+var emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
+
+function emailDetector(value, path) {
+  return emailRegex.test(value);
+};
+
+parseSchema(db.collection('data').find(), {EmailAddress: emailDetector}, function(err, schema) {
+  ...
+});
+```
+
+This returns a schema with the following content (only partially shown):
+
+```
+{
+  "name": "email",
+  "path": "email",
+  "count": 100,
+  "types": [
+    {
+      "name": "EmailAddress",     // custom type "EmailAddress" was recognized
+      "bsonType": "String",       // original BSON type available as well
+      "path": "email",
+      "count": 100,
+      "values": [
+        "twinbutterfly28@aim.com",
+        "funkymoney45@comcast.net",
+        "beauty68@msn.com",
+        "veryberry8@hotmail.com",
+
+```
+
+As can be seen, the field name "email" was correctly identified as a custom type "EmailAddress".
 
 ## Value Sampling
 

--- a/bin/mongodb-schema
+++ b/bin/mongodb-schema
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint no-console: 0 */
+
 var schemaStream = require('../lib/stream');
 var schemaStats = require('../lib/stats');
 
@@ -54,6 +56,17 @@ var argv = require('yargs')
     type: 'boolean',
     default: true,
     describe: 'promote values to Javascript numbers.'
+  })
+  .options('t', {
+    alias: 'semantic-types',
+    type: 'boolean',
+    default: false,
+    describe: 'semantic type detection, currently supported are emails and geojson'
+  })
+  .option('values', {
+    type: 'boolean',
+    default: true,
+    describe: 'enables the collection of sample values'
   })
   .option('sampling', {
     type: 'boolean',
@@ -145,6 +158,10 @@ mongodb.connect(uri, function(err, conn) {
   };
 
   var schema;
+  var schemaOptions = {
+    storeValues: argv.values,
+    semanticTypes: argv.semanticTypes
+  };
 
   async.timesSeries(argv.repeat, function(arr, cb) {
     var source = argv.sampling ?
@@ -157,7 +174,7 @@ mongodb.connect(uri, function(err, conn) {
       .once('data', function() {
         ts = new Date();
       })
-      .pipe(schemaStream())
+      .pipe(schemaStream(schemaOptions))
       .on('progress', function() {
         bar.tick();
       })
@@ -168,9 +185,9 @@ mongodb.connect(uri, function(err, conn) {
         var dur = new Date() - ts;
         cb(null, dur);
       });
-  }, function(err, res) {
-    if (err) {
-      console.error('error:', err.message);
+  }, function(err2, res) {
+    if (err2) {
+      console.error('error:', err2.message);
       process.exit(1);
     }
     if (argv.output) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,21 @@ var _ = require('lodash');
  * Convenience shortcut for parsing schemas. Accepts an array, stream or
  * MongoDB cursor object to parse documents from.
  *
- * @param {Cursor|
- *          Array|
- *         Stream} docs   An array, a cursor, or a stream
- * @param {Function} fn   Callback which will be passed `(err, schema)`
+ * @param {Cursor|Array|Stream}  docs      An array, a cursor, or a stream
+ *
+ * @param {Object}   options                options (optional)
+ * @param {Boolean}  options.semanticTypes  enable semantic type detection (default: false)
+ * @param {Boolean}  options.storeValues    enable storing of values (default: true)
+ *
+ * @param {Function} fn      Callback which will be passed `(err, schema)`
  */
-module.exports = function(docs, fn) {
+module.exports = function(docs, options, fn) {
+  // shift parameters if no options are specified
+  if (_.isUndefined(options) || _.isFunction(options) && _.isUndefined(fn)) {
+    fn = options;
+    options = {};
+  }
+
   var src;
   // MongoDB Cursors
   if (docs.stream && typeof docs.stream === 'function') {
@@ -31,7 +40,8 @@ module.exports = function(docs, fn) {
   }
 
   var result;
-  src.pipe(stream())
+
+  src.pipe(stream(options))
     .on('data', function(data) {
       result = data;
     })

--- a/lib/semantic-types/email.js
+++ b/lib/semantic-types/email.js
@@ -1,0 +1,6 @@
+// from http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
+var emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
+
+module.exports = function(value) {
+  return emailRegex.test(value);
+};

--- a/lib/semantic-types/geojson.js
+++ b/lib/semantic-types/geojson.js
@@ -1,0 +1,5 @@
+var gvl = require('geojson-validation');
+
+module.exports = function(value) {
+  return gvl.isGeoJSONObject(value);
+};

--- a/lib/semantic-types/index.js
+++ b/lib/semantic-types/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  'Email': require('./email'),
+  'GeoJSON': require('./geojson')
+};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -190,17 +190,8 @@ module.exports = function parse(options) {
    * @return {String}      type as string, e.g. `ObjectId`, `Document`, `Date`,
    *                       `Number`, `Undefined`, `Boolean`, ...
    */
-  var getTypeName = function(value, path) {
+  var getBSONType = function(value) {
     var T;
-    if (options.semanticTypes) {
-      // pass value to semantic type detectors, return first match or undefined
-      T = _.findKey(semanticTypes, function(fn) {
-        return fn(value, path);
-      });
-      if (T) {
-        return T;
-      }
-    }
     if (_.has(value, '_bsontype')) {
       T = value._bsontype;
     } else {
@@ -210,6 +201,13 @@ module.exports = function parse(options) {
       T = 'Document';
     }
     return T;
+  };
+
+  var getSemanticType = function(value, path) {
+    // pass value to semantic type detectors, return first match or undefined
+    return _.findKey(semanticTypes, function(fn) {
+      return fn(value, path);
+    });
   };
 
   /**
@@ -239,9 +237,15 @@ module.exports = function parse(options) {
    */
 
   var addToType = function(path, value, schema) {
-    var typeName = getTypeName(value, path);
+    var bsonType = getBSONType(value);
+    // if semantic type detection is enabled, the type is the semantic type
+    // or the original bson type if no semantic type was detected. If disabled,
+    // it is always the bson type.
+    var typeName = (options.semanticTypes) ?
+      getSemanticType(value, path) || bsonType : bsonType;
     var type = schema[typeName] = _.get(schema, typeName, {
       name: typeName,
+      bsonType: bsonType,
       path: path,
       count: 0
     });
@@ -264,7 +268,7 @@ module.exports = function parse(options) {
 
     // if the `storeValues` option is enabled, store some example values
     } else if (options.storeValues) {
-      type.values = _.get(type, 'values', type.name === 'String' ?
+      type.values = _.get(type, 'values', bsonType === 'String' ?
         new Reservoir(100) : new Reservoir(10000));
       addToValue(type, value);
     }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -26,79 +26,6 @@ var extractStringValueFromBSON = function(value) {
   return String(value);
 };
 
-/**
- * Returns the type of value as a string. BSON type aware. Replaces `Object`
- * with `Document` to avoid naming conflicts with javascript Objects.
- *
- * @param  {Any} value   value for which to get the type
- * @return {String}      type as string, e.g. `ObjectId`, `Document`, `Date`,
- *                       `Number`, `Undefined`, `Boolean`, ...
- */
-var getTypeName = function(value) {
-  var T;
-  if (_.has(value, '_bsontype')) {
-    T = value._bsontype;
-  } else {
-    T = Object.prototype.toString.call(value).replace(/\[object (\w+)\]/, '$1');
-  }
-  if (T === 'Object') {
-    T = 'Document';
-  }
-  return T;
-};
-
-var addToField;
-
-var addToValue = function(type, value) {
-  if (type.name === 'String') {
-    // crop strings at 10k characters
-    if (value.length > 10000) {
-      value = value.slice(0, 10000);
-    }
-  }
-  type.values.pushSome(value);
-};
-
-var addToType = function(path, value, schema) {
-  var typeName = getTypeName(value);
-  var type = schema[typeName] = _.get(schema, typeName, {
-    name: typeName,
-    path: path,
-    count: 0
-  });
-  type.count++;
-  // debug('added to type', type);
-  if (typeName === 'Array') {
-    type.types = _.get(type, 'types', {});
-    type.lengths = _.get(type, 'lengths', []);
-    type.lengths.push(value.length);
-    _.each(value, function(v) {
-      addToType(path, v, type.types);
-    });
-  } else if (typeName === 'Document') {
-    type.fields = _.get(type, 'fields', {});
-    _.forOwn(value, function(v, k) {
-      addToField(path + '.' + k, v, type.fields);
-    });
-  } else {
-    type.values = _.get(type, 'values', type.name === 'String' ?
-      new Reservoir(100) : new Reservoir(10000));
-    addToValue(type, value);
-  }
-};
-
-addToField = function(path, value, schema) {
-  var field = schema[path] = _.get(schema, path, {
-    name: _.last(path.split('.')),
-    path: path,
-    count: 0,
-    types: {}
-  });
-  field.count++;
-  // debug('added to field', field);
-  addToType(path, value, field.types);
-};
-
 function fieldComparator(a, b) {
   // make sure _id is always at top, even in presence of uppercase fields
   var aName = a.name;
@@ -201,32 +128,183 @@ var finalizeSchema = function(schema, parent, tag) {
  * wraps finalizeSchema inside an event-stream map function (synchronous)
  */
 
-module.exports = function parse() {
+/**
+ * main entry point for schema parsing.
+ *
+ * @param {Object}          options                options (optional)
+ * @param {Boolean}         options.storeValues    enable storing of values (default: true)
+ * @param {Boolean|Object}  options.semanticTypes  enable semantic type detection (default: false)
+ *                             to enable/disable all semantic types, use true/false.
+ *                             to enable some semantic types, use object notation
+ *                             with lowercase keys and truthy values:
+ *                             `{email: true, geojson: true}` will only use email and
+ *                             GeoJSON detection.
+ *
+ * @return {Stream}  The parser through tream
+ */
+module.exports = function parse(options) {
   /* eslint no-sync: 0 */
 
-  var schema = {
+  // set default options
+  options = _.defaults({}, options, {
+    semanticTypes: false,
+    storeValues: true
+  });
+
+  var semanticTypes = require('./semantic-types');
+
+  if (_.isObject(options.semanticTypes)) {
+    // enable existing types that evaluate to true
+    var enabledTypes = _(options.semanticTypes)
+      .pick(function(val) {
+        return _.isBoolean(val) && val;
+      })
+      .keys()
+      .map(function(val) {
+        return val.toLowerCase();
+      })
+      .value();
+    semanticTypes = _.pick(semanticTypes, function(val, key) {
+      return _.includes(enabledTypes, key.toLowerCase());
+    });
+    // merge with custom types that are functions
+    semanticTypes = _.assign(semanticTypes,
+      _.pick(options.semanticTypes, _.isFunction)
+    );
+  }
+
+  var rootSchema = {
     fields: {},
     count: 0
   };
 
   var finalized = false;
+  var addToField;
+
+  /**
+   * Returns the type of value as a string. BSON type aware. Replaces `Object`
+   * with `Document` to avoid naming conflicts with javascript Objects.
+   *
+   * @param  {Any} value   value for which to get the type
+   * @param  {Any} path    path (in dot notation) for which to get the type
+   * @return {String}      type as string, e.g. `ObjectId`, `Document`, `Date`,
+   *                       `Number`, `Undefined`, `Boolean`, ...
+   */
+  var getTypeName = function(value, path) {
+    var T;
+    if (options.semanticTypes) {
+      // pass value to semantic type detectors, return first match or undefined
+      T = _.findKey(semanticTypes, function(fn) {
+        return fn(value, path);
+      });
+      if (T) {
+        return T;
+      }
+    }
+    if (_.has(value, '_bsontype')) {
+      T = value._bsontype;
+    } else {
+      T = Object.prototype.toString.call(value).replace(/\[object (\w+)\]/, '$1');
+    }
+    if (T === 'Object') {
+      T = 'Document';
+    }
+    return T;
+  };
+
+  /**
+   * handles adding the value to the value reservoir. Will also crop
+   * strings at 10,000 characters.
+   *
+   * @param {Object} type    the type object from `addToType`
+   * @param {Any}    value   the value to be added to `type.values`
+   */
+  var addToValue = function(type, value) {
+    if (type.name === 'String') {
+      // crop strings at 10k characters
+      if (value.length > 10000) {
+        value = value.slice(0, 10000);
+      }
+    }
+    type.values.pushSome(value);
+  };
+
+  /**
+   * Takes a field value, determines the correct type, handles recursion into
+   * nested arrays and documents, and passes the value down to `addToValue`.
+   *
+   * @param {String}  path     field path in dot notation
+   * @param {Any}     value    value of the field
+   * @param {Object}  schema   the updated schema object
+   */
+
+  var addToType = function(path, value, schema) {
+    var typeName = getTypeName(value, path);
+    var type = schema[typeName] = _.get(schema, typeName, {
+      name: typeName,
+      path: path,
+      count: 0
+    });
+    type.count++;
+    // recurse into arrays by calling `addToType` for each element
+    if (typeName === 'Array') {
+      type.types = _.get(type, 'types', {});
+      type.lengths = _.get(type, 'lengths', []);
+      type.lengths.push(value.length);
+      _.each(value, function(v) {
+        addToType(path, v, type.types);
+      });
+
+    // recurse into nested documents by calling `addToField` for all sub-fields
+    } else if (typeName === 'Document') {
+      type.fields = _.get(type, 'fields', {});
+      _.forOwn(value, function(v, k) {
+        addToField(path + '.' + k, v, type.fields);
+      });
+
+    // if the `storeValues` option is enabled, store some example values
+    } else if (options.storeValues) {
+      type.values = _.get(type, 'values', type.name === 'String' ?
+        new Reservoir(100) : new Reservoir(10000));
+      addToValue(type, value);
+    }
+  };
+
+  /**
+   * handles a field from a document. Passes the value to `addToType`.
+   *
+   * @param {String}  path     field path in dot notation
+   * @param {Any}     value    value of the field
+   * @param {Object}  schema   the updated schema object
+   */
+  addToField = function(path, value, schema) {
+    var field = schema[path] = _.get(schema, path, {
+      name: _.last(path.split('.')),
+      path: path,
+      count: 0,
+      types: {}
+    });
+    field.count++;
+    // debug('added to field', field);
+    addToType(path, value, field.types);
+  };
 
   function cleanup() {
     if (!finalized) {
-      finalizeSchema(schema);
+      finalizeSchema(rootSchema);
       finalized = true;
     }
   }
 
   var parser = es.through(function write(obj) {
     _.each(_.keys(obj), function(key) {
-      addToField(key, obj[key], schema.fields);
+      addToField(key, obj[key], rootSchema.fields);
     });
-    schema.count += 1;
+    rootSchema.count += 1;
     this.emit('progress', obj);
   }, function end() {
     cleanup();
-    this.emit('data', schema);
+    this.emit('data', rootSchema);
     this.emit('end');
   });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "event-stream": "^3.3.0",
+    "geojson-validation": "^0.1.6",
     "lodash": "^3.8.0",
     "progress": "^1.1.8",
     "reservoir": "^0.1.2"

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,0 +1,152 @@
+var getSchema = require('../');
+var assert = require('assert');
+var BSON = require('bson');
+var _ = require('lodash');
+
+// var debug = require('debug')('mongodb-schema:test:options');
+
+/* eslint new-cap: 0, quote-props: 0, no-new: 0, camelcase: 0 */
+describe('options', function() {
+  var docs = [
+    {
+      '_id': BSON.ObjectID('55581e0a9bf712d0c2b48d71'),
+      'email': 'tick@duck.org',
+      'shape': {
+        type: 'Point',
+        coordinates: [20.0, 30.0]
+      },
+      'is_verified': false
+    },
+    {
+      '_id': BSON.ObjectID('55581e0a9bf712d0c2b48d72'),
+      'email': 'trick@duck.org',
+      'shape': {
+        type: 'LineString',
+        coordinates: [[20.0, 30.0], [30.0, 40.0]]
+      },
+      'is_verified': false
+    },
+    {
+      '_id': BSON.ObjectID('55581e0a9bf712d0c2b48d73'),
+      'email': 'track@duck.org',
+      'shape': {
+        'type': 'Polygon',
+        'coordinates': [[[20.0, 30.0], [30.0, 40.0], [15.0, 50.0], [20.0, 30.0]]]
+      },
+      'is_verified': true
+    }
+  ];
+
+  var schema;
+  context('when using default options', function() {
+    beforeEach(function(done) {
+      getSchema(docs, function(err, res) {
+        assert.ifError(err);
+        schema = res;
+        done();
+      });
+    });
+
+    it('stores values by default', function() {
+      assert.equal(schema.fields[0].types[0].values.length, 3);
+    });
+
+    it('does not use semantic type detection', function() {
+      assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'String');
+      assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+    });
+  });
+
+  context('when `storeValues` is false', function() {
+    beforeEach(function(done) {
+      getSchema(docs, {storeValues: false}, function(err, res) {
+        assert.ifError(err);
+        schema = res;
+        done();
+      });
+    });
+    it('does not store values when `storeValues` is false', function() {
+      assert.ok(!schema.fields[0].types[0].values);
+    });
+  });
+
+  context('when `semanticTypes` is true', function() {
+    beforeEach(function(done) {
+      getSchema(docs, {semanticTypes: true}, function(err, res) {
+        assert.ifError(err);
+        schema = res;
+        done();
+      });
+    });
+    it('calls semantic type detection', function() {
+      assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+      assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'GeoJSON');
+    });
+    it('stores whole GeoJSON objects as values', function() {
+      assert.ok(_.find(schema.fields, 'name', 'shape').types[0].values[0].type);
+      assert.ok(_.find(schema.fields, 'name', 'shape').types[0].values[0].coordinates);
+    });
+  });
+  context('when `semanticTypes` is an object', function() {
+    context('and all values are boolean', function() {
+      beforeEach(function(done) {
+        getSchema(docs, {semanticTypes: {email: true}}, function(err, res) {
+          assert.ifError(err);
+          schema = res;
+          done();
+        });
+      });
+      it('only uses the enabled type detectors', function() {
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+      });
+    });
+    context('and values are mixed upper/lower case', function() {
+      beforeEach(function(done) {
+        getSchema(docs, {semanticTypes: {geoJSOn: true, eMaIl: true}}, function(err, res) {
+          assert.ifError(err);
+          schema = res;
+          done();
+        });
+      });
+      it('uses the enabled type detectors', function() {
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'GeoJSON');
+      });
+    });
+
+    context('and all values are custom detector functions', function() {
+      beforeEach(function(done) {
+        getSchema(docs, {semanticTypes: {Verification: function(value, key) {
+          return key.match(/verified/);
+        }}}, function(err, res) {
+          assert.ifError(err);
+          schema = res;
+          done();
+        });
+      });
+      it('uses the custom type detectors', function() {
+        assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].name, 'Verification');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'String');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+      });
+    });
+
+    context('and values are mixed booleans and custom detector functions', function() {
+      beforeEach(function(done) {
+        getSchema(docs, {semanticTypes: {email: true, Verification: function(value, key) {
+          return key.match(/verified/);
+        }}}, function(err, res) {
+          assert.ifError(err);
+          schema = res;
+          done();
+        });
+      });
+      it('uses the enabled and custom type detectors', function() {
+        assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].name, 'Verification');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+      });
+    });
+  });
+});

--- a/test/semantic-types.test.js
+++ b/test/semantic-types.test.js
@@ -53,7 +53,9 @@ describe('options', function() {
 
     it('does not use semantic type detection', function() {
       assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'String');
+      assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
       assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+      assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
     });
   });
 
@@ -80,7 +82,9 @@ describe('options', function() {
     });
     it('calls semantic type detection', function() {
       assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+      assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
       assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'GeoJSON');
+      assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
     });
     it('stores whole GeoJSON objects as values', function() {
       assert.ok(_.find(schema.fields, 'name', 'shape').types[0].values[0].type);
@@ -98,7 +102,9 @@ describe('options', function() {
       });
       it('only uses the enabled type detectors', function() {
         assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
         assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
       });
     });
     context('and values are mixed upper/lower case', function() {
@@ -111,7 +117,9 @@ describe('options', function() {
       });
       it('uses the enabled type detectors', function() {
         assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
         assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'GeoJSON');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
       });
     });
 
@@ -127,8 +135,11 @@ describe('options', function() {
       });
       it('uses the custom type detectors', function() {
         assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].name, 'Verification');
+        assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].bsonType, 'Boolean');
         assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'String');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
         assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
       });
     });
 
@@ -144,8 +155,11 @@ describe('options', function() {
       });
       it('uses the enabled and custom type detectors', function() {
         assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].name, 'Verification');
+        assert.equal(_.find(schema.fields, 'name', 'is_verified').types[0].bsonType, 'Boolean');
         assert.equal(_.find(schema.fields, 'name', 'email').types[0].name, 'Email');
+        assert.equal(_.find(schema.fields, 'name', 'email').types[0].bsonType, 'String');
         assert.equal(_.find(schema.fields, 'name', 'shape').types[0].name, 'Document');
+        assert.equal(_.find(schema.fields, 'name', 'shape').types[0].bsonType, 'Document');
       });
     });
   });


### PR DESCRIPTION
Semantic types enable users to provide domain knowledge of their stored data. While MongoDB's flexible schema model enables storing any type of data, there is ...

See README for additional explanation of the features.