### PR TITLE
Update travis.yml: Add node 6.3.1 & 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- '0.12'
+  - '0.12'
+  - 6.3.1
+  - 7.4
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
For our required Electron support versions 1.2.8 and 1.6.1