### PR TITLE
COMPASS-1797 Fields 'foo' and 'foo[]' can cause 'foo[]' to disappear

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -282,12 +282,17 @@ module.exports = function parse(options) {
    * @param {Object}  schema   the updated schema object
    */
   addToField = function(path, value, schema) {
-    var field = schema[path] = _.get(schema, path, {
+    var defaults = {};
+
+    defaults[path] = {
       name: _.last(path.split('.')),
       path: path,
       count: 0,
       types: {}
-    });
+    };
+    _.defaultsDeep(schema, defaults);
+    var field = schema[path];
+
     field.count++;
     // debug('added to field', field);
     addToType(path, value, field.types);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -18,7 +18,8 @@ describe('using only basic fields', function() {
       'last_address_latitude': null,
       'last_address_longitude': null,
       'created_at': new Date(),
-      'length': 29
+      'length': 29,
+      'name[]': 'Annabeth Frankie'
     }
   ];
 
@@ -36,7 +37,8 @@ describe('using only basic fields', function() {
       'length',
       'name',
       'stats_friends',
-      'twitter_username'
+      'twitter_username',
+      'name[]'
     ];
     assert.deepEqual(_.pluck(users.fields, 'name').sort(), field_names.sort());
   });


### PR DESCRIPTION
Allowing to have array like field names in schema