### PR TITLE
fix example read from file

### DIFF
--- a/examples/parse-from-file.js
+++ b/examples/parse-from-file.js
@@ -1,12 +1,13 @@
 /* eslint no-console: 0 */
 
 var stream = require('../lib/stream');
-var fs = require('fs');
 var es = require('event-stream');
+var path = require('path');
+var fs = require('fs');
 
 var ts = new Date();
 
-fs.createReadStream('./fanclub.json', {
+fs.createReadStream(path.join(__dirname, './fanclub.json'), {
   flags: 'r'
 })
   .pipe(es.split()) // split file into individual json docs (one per line)


### PR DESCRIPTION
With newer versions of node you need to specifically provide a path (i think older versions of node let you just give a string) when creating a read stream. example file doesn't work without supplying a proper path.