### PR TITLE
access _bsontype directly instead of _.has

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -12,7 +12,7 @@ var Reservoir = require('reservoir');
 * @return {String}       converted value
 */
 var extractStringValueFromBSON = function(value) {
-  if (_.has(value, '_bsontype')) {
+  if (value && value._bsontype) {
     if (_.includes([ 'Decimal128', 'Long' ], value._bsontype)) {
       return value.toString();
     }
@@ -192,7 +192,7 @@ module.exports = function parse(options) {
    */
   var getBSONType = function(value) {
     var T;
-    if (_.has(value, '_bsontype')) {
+    if (value && value._bsontype) {
       T = value._bsontype;
     } else {
       T = Object.prototype.toString.call(value).replace(/\[object (\w+)\]/, '$1');


### PR DESCRIPTION
In the latest version of `bson` library, `_bsontype` property is added to value's prototype, but `_.has` only looks for in object's own properties. This means incorrect type might be returned. This PR fixes the issue by access the `_bsontype` directly.