### PR TITLE
Help needed; Updated lodash and removed renamed/deprecated fn's

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -83,12 +83,12 @@ var finalizeSchema = function(schema, parent, tag) {
 
       // recursively finalize types
       finalizeSchema(field.types, field, 'types');
-      field.type = _.pluck(field.types, 'name');
+      field.type = _.map(field.types, 'name');
       if (field.type.length === 1) {
         field.type = field.type[0];
       }
       // a field has duplicates when any of its types have duplicates
-      field.has_duplicates = _.any(field.types, 'has_duplicates');
+      field.has_duplicates = _.some(field.types, 'has_duplicates');
       // compute probability
       field.probability = field.count / parent.count;
     });
@@ -119,7 +119,7 @@ var finalizeSchema = function(schema, parent, tag) {
       }
       // recursively finalize fields and types
     });
-    parent.types = _.sortByOrder(_.values(parent.types), 'probability', 'desc');
+    parent.types = _.orderBy(_.values(parent.types), 'probability', 'desc');
   }
   return schema;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3589,7 +3589,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3785,8 +3784,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3876,8 +3874,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5590,9 +5587,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -6873,8 +6870,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "optional": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "0.2.9",
@@ -9510,6 +9506,12 @@
           "requires": {
             "ms": "0.6.2"
           }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         },
         "ms": {
           "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "event-stream": "^4.0.1",
-    "lodash": "^3.8.0",
+    "lodash": "^4.17.20",
     "progress": "^2.0.3",
     "reservoir": "^0.1.2"
   },

--- a/test/array-object-types.test.js
+++ b/test/array-object-types.test.js
@@ -46,8 +46,8 @@ describe('arrays and objects as type (INT-203 restructuring)', function() {
     });
     it('have the right type distribution of x', function() {
       var dist = _.zipObject(
-        _.pluck(x.types, 'name'),
-        _.pluck(x.types, 'probability')
+        _.map(x.types, 'name'),
+        _.map(x.types, 'probability')
       );
       assert.deepEqual(dist, {
         'Array': 3 / 6,
@@ -79,8 +79,8 @@ describe('arrays and objects as type (INT-203 restructuring)', function() {
 
     it('should return the type distribution inside an array', function() {
       var arrDist = _.zipObject(
-        _.pluck(arr.types, 'name'),
-        _.pluck(arr.types, 'probability')
+        _.map(arr.types, 'name'),
+        _.map(arr.types, 'probability')
       );
       assert.deepEqual(arrDist, {
         'Number': 3 / 8,

--- a/test/basic-embedded-array.test.js
+++ b/test/basic-embedded-array.test.js
@@ -37,7 +37,7 @@ describe('basic embedded array', function() {
   });
 
   it('should have a sum of probability for following_ids of 1', function() {
-    assert.equal(_.sum(_.pluck(following_ids.types, 'probability')), 1);
+    assert.equal(_.sum(_.map(following_ids.types, 'probability')), 1);
   });
 
   it('should have 33% String for following_ids', function() {

--- a/test/basic-embedded-documents.test.js
+++ b/test/basic-embedded-documents.test.js
@@ -57,9 +57,9 @@ describe('basic embedded documents', function() {
       'push_token.apple'
     ];
 
-    assert.deepEqual(_.pluck(schema.fields, 'name').sort(), field_names.sort());
+    assert.deepEqual(_.map(schema.fields, 'name').sort(), field_names.sort());
     var push_tokens = _.find(_.find(schema.fields, 'name', 'push_token').types,
       'name', 'Document').fields;
-    assert.deepEqual(_.pluck(push_tokens, 'path').sort(), nested_path_names.sort());
+    assert.deepEqual(_.map(push_tokens, 'path').sort(), nested_path_names.sort());
   });
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -40,7 +40,7 @@ describe('using only basic fields', function() {
       'twitter_username',
       'name[]'
     ];
-    assert.deepEqual(_.pluck(users.fields, 'name').sort(), field_names.sort());
+    assert.deepEqual(_.map(users.fields, 'name').sort(), field_names.sort());
   });
 
   before(function(done) {

--- a/test/field-order.test.js
+++ b/test/field-order.test.js
@@ -14,7 +14,7 @@ describe('order of fields', function() {
     }];
     getSchema(docs, function(err, schema) {
       assert.ifError(err);
-      assert.deepEqual(_.pluck(schema.fields, 'name'), ['_id', 'BAR', 'FOO', 'zoo']);
+      assert.deepEqual(_.map(schema.fields, 'name'), ['_id', 'BAR', 'FOO', 'zoo']);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('order of fields', function() {
     }];
     getSchema(docs, function(err, schema) {
       assert.ifError(err);
-      assert.deepEqual(_.pluck(schema.fields, 'name'), ['a', 'b', 'Ca', 'cb', 'cC']);
+      assert.deepEqual(_.map(schema.fields, 'name'), ['a', 'b', 'Ca', 'cb', 'cC']);
       done();
     });
   });

--- a/test/mixed-type-order.test.js
+++ b/test/mixed-type-order.test.js
@@ -40,7 +40,7 @@ describe('mixed type order', function() {
     assert.equal(registered.types.length, 3);
   });
   it('should return the order of types as ["String", "Number", "Undefined"]', function(done) {
-    assert.deepEqual(_.pluck(registered.types, 'name'),
+    assert.deepEqual(_.map(registered.types, 'name'),
       ['String', 'Number', 'Undefined']);
     done();
   });


### PR DESCRIPTION
Help needed. Tried updating lodash, but I have multiple issues with the specs. Trying to work me way through the change-log, but it's quite big 😅

After replacing the deprecated fn's, in the `lib` folder, the following functions are in use and manually checked (docs for [v3  here](https://lodash.com/docs/3.10.1), and [v4 here](https://lodash.com/docs/4.17.15).

- [X] .isUndefined
- [X] .isFunction
- [X] .isArray
- [X] .isString
- [ ] .isObject
- [ ] .isBoolean
- [ ] .sum
- [ ] .find
- [ ] .findKey
- [ ] .max
- [ ] .flatten
- [ ] .sortBy    <== previous `_.sortByOrder`
- [ ] .includes
- [ ] .map        <== previous `_.pluck`
- [ ] .orderBy
- [ ] .assign
- [ ] .pick
- [ ] .get
- [ ] .last
- [ ] .forOwn
- [ ] .each
- [ ] .keys
- [ ] .defaults
- [ ] .defaultsDeep
- [ ] .some    <== previous `_.any`
- [ ] .uniq
- [ ] .values

I used this document as reference:

https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings