### PR TITLE
Added promise support for library

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,11 +3,9 @@
     "ecmaVersion": 2017
   },
   "env": {
-      "es6": true
-  }
-  "env": {
     "mocha": true,
-    "node": true
+    "node": true,
+    "es6": true
   },
   "globals": {
     "expect": true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
-var stream = require('./stream');
-var es = require('event-stream');
-var _ = require('lodash');
+var stream = require("./stream");
+var es = require("event-stream");
+var _ = require("lodash");
 
 // var debug = require('debug')('mongodb-schema:wrapper');
 
@@ -16,41 +16,52 @@ var _ = require('lodash');
  *
  * @param {Function} fn      Callback which will be passed `(err, schema)`
  */
-module.exports = function(docs, options, fn) {
-  // shift parameters if no options are specified
-  if (_.isUndefined(options) || _.isFunction(options) && _.isUndefined(fn)) {
-    fn = options;
-    options = {};
+module.exports = function (docs, options, callback) {
+  const promise = new Promise((resolve, reject) => {
+    // shift parameters if no options are specified
+    if (_.isUndefined(options) || (_.isFunction(options) && _.isUndefined(callback))) {
+      callback = options;
+      options = {};
+    }
+
+    var src;
+    // MongoDB Cursors
+    if (docs.stream && typeof docs.stream === "function") {
+      src = docs.stream();
+      // Streams
+    } else if (docs.pipe && typeof docs.pipe === "function") {
+      src = docs;
+      // Arrays
+    } else if (_.isArray(docs)) {
+      src = es.readArray(docs);
+    } else {
+      reject(new Error(
+        "Unknown input type for `docs`. Must be an array, " +
+          "stream or MongoDB Cursor."
+      ));
+      return;
+    }
+
+    var result;
+
+    src
+      .pipe(stream(options))
+      .on("data", function (data) {
+        result = data;
+      })
+      .on("error", function (err) {
+        reject(err);
+      })
+      .on("end", function () {
+        resolve(result);
+      });
+  });
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
   }
 
-  var src;
-  // MongoDB Cursors
-  if (docs.stream && typeof docs.stream === 'function') {
-    src = docs.stream();
-  // Streams
-  } else if (docs.pipe && typeof docs.pipe === 'function') {
-    src = docs;
-  // Arrays
-  } else if (_.isArray(docs)) {
-    src = es.readArray(docs);
-  } else {
-    fn(new Error('Unknown input type for `docs`. Must be an array, '
-      + 'stream or MongoDB Cursor.'));
-    return;
-  }
-
-  var result;
-
-  src.pipe(stream(options))
-    .on('data', function(data) {
-      result = data;
-    })
-    .on('error', function(err) {
-      fn(err);
-    })
-    .on('end', function() {
-      fn(null, result);
-    });
+  return promise;
 };
 
 module.exports.stream = stream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
-var stream = require("./stream");
-var es = require("event-stream");
-var _ = require("lodash");
+var stream = require('./stream');
+var es = require('event-stream');
+var _ = require('lodash');
 
 // var debug = require('debug')('mongodb-schema:wrapper');
 
@@ -14,9 +14,10 @@ var _ = require("lodash");
  * @param {Boolean}  options.semanticTypes  enable semantic type detection (default: false)
  * @param {Boolean}  options.storeValues    enable storing of values (default: true)
  *
- * @param {Function} fn      Callback which will be passed `(err, schema)`
+ * @param {Function} callback      Callback which will be passed `(err, schema)`
+ * @return {Promise} You can await promise, or use callback if provided.
  */
-module.exports = function (docs, options, callback) {
+module.exports = function(docs, options, callback) {
   const promise = new Promise((resolve, reject) => {
     // shift parameters if no options are specified
     if (_.isUndefined(options) || (_.isFunction(options) && _.isUndefined(callback))) {
@@ -26,18 +27,18 @@ module.exports = function (docs, options, callback) {
 
     var src;
     // MongoDB Cursors
-    if (docs.stream && typeof docs.stream === "function") {
+    if (docs.stream && typeof docs.stream === 'function') {
       src = docs.stream();
       // Streams
-    } else if (docs.pipe && typeof docs.pipe === "function") {
+    } else if (docs.pipe && typeof docs.pipe === 'function') {
       src = docs;
       // Arrays
     } else if (_.isArray(docs)) {
       src = es.readArray(docs);
     } else {
       reject(new Error(
-        "Unknown input type for `docs`. Must be an array, " +
-          "stream or MongoDB Cursor."
+        'Unknown input type for `docs`. Must be an array, ' +
+          'stream or MongoDB Cursor.'
       ));
       return;
     }
@@ -46,18 +47,18 @@ module.exports = function (docs, options, callback) {
 
     src
       .pipe(stream(options))
-      .on("data", function (data) {
+      .on('data', function(data) {
         result = data;
       })
-      .on("error", function (err) {
+      .on('error', function(err) {
         reject(err);
       })
-      .on("end", function () {
+      .on('end', function() {
         resolve(result);
       });
   });
 
-  if (callback && typeof callback == 'function') {
+  if (callback && typeof callback === 'function') {
     promise.then(callback.bind(null, null), callback);
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "zuul --local 3001 --open -- test/*.test.js",
     "test": "mocha",
     "ci": "./node_modules/istanbul/lib/cli.js cover _mocha -- -R spec ./test/*.test.js",
-    "check": "mongodb-js-precommit"
+    "check": "mongodb-js-precommit",
+    "lint": "eslint lib test examples --fix"
   },
   "precommit": [
     "check"

--- a/test/promise-or-callback.test.js
+++ b/test/promise-or-callback.test.js
@@ -1,61 +1,64 @@
 var getSchema = require('../');
 var assert = require('assert');
-var _ = require("lodash");
+var _ = require('lodash');
 
 describe('getSchema should return promise', function() {
-    var docs = [
-        { foo: 'bar'},
-        { country: 'Croatia'},
-        { country: 'Croatia'},
-        { country: 'England'},
-    ]
+  var docs = [
+    { foo: 'bar'},
+    { country: 'Croatia'},
+    { country: 'Croatia'},
+    { country: 'England'},
+  ];
 
-    it('Check if return value is a promise', () => {
-        var result = getSchema(docs);
-        assert.strictEqual(result instanceof Promise, true);
+  it('Check if return value is a promise', () => {
+    var result = getSchema(docs);
+    assert.strictEqual(result instanceof Promise, true);
+  });
+
+  it('Check that promise returns expected schema', async() => {
+    const result = await getSchema(docs);
+    const fieldNames = result.fields.map(v => v.name);
+    assert.deepStrictEqual(fieldNames, ['country', 'foo']);
+  });
+
+  describe('Check callback and promise return the same thing; success', () => {
+    let promiseResponse;
+    let callbackResponse;
+
+    before((done) => {
+      getSchema(docs).then((result) => {
+        promiseResponse = result;
+      });
+      getSchema(docs, (err, callbackResult) => {
+        if (err) {
+          throw err;
+        }
+        callbackResponse = callbackResult;
+        done();
+      });
     });
 
-    it('Check that promise returns expected schema', async () => {
-        const result = await getSchema(docs);
-        const fieldNames = result.fields.map(v => v.name);
-        assert.deepStrictEqual(fieldNames, ['country', 'foo']);
-    })
+    it('Using callback and promise should return the same thing', () => {
+      assert(_.isEqual(promiseResponse, callbackResponse));
+    });
+  });
 
-    describe('Check callback and promise return the same thing; success', () => {
+  describe('Check callback and promise return the same thing; failure', () => {
+    let promiseErrMessage;
+    let callbackErrMessage;
 
-        let promiseResponse;
-        let callbackResponse;
-
-        before((done) => {
-            getSchema(docs).then((result) => promiseResponse = result);
-            getSchema(docs, (err, callbackResult) => {
-                callbackResponse = callbackResult;
-                done();
-            })
+    before((done) => {
+      getSchema({foo: 'bar'}, (err) => {
+        getSchema({foo: 'bar'}).catch(error => {
+          promiseErrMessage = error.message;
         });
-
-        it('Using callback and promise should return the same thing', () => {
-            assert(_.isEqual(promiseResponse, callbackResponse))
-        });
+        callbackErrMessage = err.message;
+        done();
+      });
     });
 
-    describe('Check callback and promise return the same thing; failure', () => {
-
-        let promiseErrMessage;
-        let callbackErrMessage;
-
-        before((done) => {
-            
-            getSchema({foo: 'bar'}, (err) => {
-                getSchema({foo: 'bar'}).catch(err => promiseErrMessage = err.message)
-                callbackErrMessage = err.message;
-                done();
-            })
-        });
-
-        it('Using callback and promise should give same err message', () => {
-            assert.strictEqual(promiseErrMessage, callbackErrMessage);
-        });
+    it('Using callback and promise should give same err message', () => {
+      assert.strictEqual(promiseErrMessage, callbackErrMessage);
     });
-
+  });
 });

--- a/test/promise-or-callback.test.js
+++ b/test/promise-or-callback.test.js
@@ -1,0 +1,61 @@
+var getSchema = require('../');
+var assert = require('assert');
+var _ = require("lodash");
+
+describe('getSchema should return promise', function() {
+    var docs = [
+        { foo: 'bar'},
+        { country: 'Croatia'},
+        { country: 'Croatia'},
+        { country: 'England'},
+    ]
+
+    it('Check if return value is a promise', () => {
+        var result = getSchema(docs);
+        assert.strictEqual(result instanceof Promise, true);
+    });
+
+    it('Check that promise returns expected schema', async () => {
+        const result = await getSchema(docs);
+        const fieldNames = result.fields.map(v => v.name);
+        assert.deepStrictEqual(fieldNames, ['country', 'foo']);
+    })
+
+    describe('Check callback and promise return the same thing; success', () => {
+
+        let promiseResponse;
+        let callbackResponse;
+
+        before((done) => {
+            getSchema(docs).then((result) => promiseResponse = result);
+            getSchema(docs, (err, callbackResult) => {
+                callbackResponse = callbackResult;
+                done();
+            })
+        });
+
+        it('Using callback and promise should return the same thing', () => {
+            assert(_.isEqual(promiseResponse, callbackResponse))
+        });
+    });
+
+    describe('Check callback and promise return the same thing; failure', () => {
+
+        let promiseErrMessage;
+        let callbackErrMessage;
+
+        before((done) => {
+            
+            getSchema({foo: 'bar'}, (err) => {
+                getSchema({foo: 'bar'}).catch(err => promiseErrMessage = err.message)
+                callbackErrMessage = err.message;
+                done();
+            })
+        });
+
+        it('Using callback and promise should give same err message', () => {
+            assert.strictEqual(promiseErrMessage, callbackErrMessage);
+        });
+    });
+
+});


### PR DESCRIPTION
Based on this excellent SO answer:
https://stackoverflow.com/a/36838115/3694288

The objective is to make the library more available and easy to use.

I was thinking about adding documentation in the README.md, bug I think most people would simply expect the promise nature of libraries these days. Maybe in the future we can have a talk about typescript support, giving end-users a better idea about the API of the library.