### PR TITLE
feat: export schema types, remove lodash dependency, speed up analysis COMPASS-6720

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,3 +1,3 @@
 ignores:
- - 'yargs'
- - 'progress'
+ - 'reservoir'
+ - '@types/reservoir'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "10.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21",
         "progress": "^2.0.3",
         "reservoir": "^0.1.2"
       },
@@ -17,7 +16,6 @@
         "mongodb-schema": "bin/mongodb-schema"
       },
       "devDependencies": {
-        "@types/lodash": "^4.14.191",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.18",
         "@types/reservoir": "^0.1.0",
@@ -2193,12 +2191,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -5488,7 +5480,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.chunk": {
       "version": "4.2.0",
@@ -9894,12 +9887,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -12311,7 +12298,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.chunk": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "nyc mocha --timeout 5000 --colors -r ts-node/register test/*.ts",
     "test-example-parse-from-file": "ts-node examples/parse-from-file.ts",
     "test-example-parse-schema": "ts-node examples/parse-schema.ts",
+    "test-time": "ts-node ./test/time-testing.ts",
     "build": "npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "prepack": "npm run build",
@@ -49,12 +50,10 @@
     "schema"
   ],
   "dependencies": {
-    "lodash": "^4.17.21",
     "progress": "^2.0.3",
     "reservoir": "^0.1.2"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.191",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",
     "@types/reservoir": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "schema"
   ],
   "dependencies": {
-    "progress": "^2.0.3",
     "reservoir": "^0.1.2"
   },
   "devDependencies": {
@@ -74,8 +73,7 @@
     "mongodb": "^5.0.1",
     "nyc": "^15.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4",
-    "yargs": "^17.6.2"
+    "typescript": "^4.9.4"
   },
   "optionalDependencies": {
     "bson": "^5.0.1",
@@ -85,6 +83,8 @@
     "mongodb-collection-sample": "^5.0.0",
     "mongodb-ns": "^2.4.0",
     "numeral": "^2.0.6",
-    "stats-lite": "^2.0.0"
+    "progress": "^2.0.3",
+    "stats-lite": "^2.0.0",
+    "yargs": "^17.6.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,17 @@ import { promisify } from 'util';
 
 import stream from './stream';
 import { SchemaAnalyzer } from './schema-analyzer';
-import type { SchemaParseOptions, Schema, SchemaField } from './schema-analyzer';
+import type {
+  ArraySchemaType,
+  BaseSchemaType,
+  ConstantSchemaType,
+  DocumentSchemaType,
+  PrimitiveSchemaType,
+  SchemaType,
+  Schema,
+  SchemaField,
+  SchemaParseOptions
+} from './schema-analyzer';
 import * as schemaStats from './stats';
 
 type MongoDBCursor = AggregationCursor | FindCursor;
@@ -23,14 +33,14 @@ async function parseSchema(
   }
 
   let src: Readable;
-  // MongoDB Cursors
   if ('stream' in docs) {
+    // MongoDB Cursor.
     src = docs.stream();
-    // Streams
   } else if ('pipe' in docs) {
+    // Document stream.
     src = docs;
-    // Arrays
   } else if (Array.isArray(docs)) {
+    // Array of documents.
     src = Readable.from(docs);
   } else {
     throw new Error(
@@ -50,7 +60,17 @@ async function parseSchema(
 
 export default parseSchema;
 
-export type { Schema, SchemaField };
+export type {
+  ArraySchemaType,
+  BaseSchemaType,
+  ConstantSchemaType,
+  DocumentSchemaType,
+  PrimitiveSchemaType,
+  SchemaType,
+  Schema,
+  SchemaField,
+  SchemaParseOptions
+};
 
 export {
   stream,

--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -1,9 +1,6 @@
-import _ from 'lodash';
 
+/* eslint-disable camelcase */
 import Reservoir from 'reservoir';
-
-import semanticTypeRegisters from './semantic-types';
-
 import type {
   Document,
   ObjectId,
@@ -20,17 +17,7 @@ import type {
   Timestamp
 } from 'bson';
 
-type BaseSchemaType = {
-  path: string;
-  count: number;
-  probability: number;
-  has_duplicates: boolean;
-  unique: number;
-}
-
-type ConstantSchemaType = BaseSchemaType & {
-  name: 'Null' | 'Undefined';
-}
+import semanticTypes from './semantic-types';
 
 type TypeCastMap = {
   Array: unknown[];
@@ -45,7 +32,7 @@ type TypeCastMap = {
   MaxKey: MaxKey;
   MinKey: MinKey;
   Null: null;
-  Object: Record<string, unknown>;
+  Object: Record<string, unknown>; // Note: In the resulting schema we rename `Object` to `Document`.
   ObjectId: ObjectId;
   BSONRegExp: BSONRegExp;
   String: string;
@@ -56,6 +43,23 @@ type TypeCastMap = {
 
 type TypeCastTypes = keyof TypeCastMap;
 type BSONValue = TypeCastMap[TypeCastTypes];
+
+export type BaseSchemaType = {
+  path: string;
+  name: string;
+  count: number;
+  probability: number;
+  bsonType: string;
+
+  // As `values` is from a sample reservoir this isn't a true check for duplicates/uniqueness.
+  // We cannot compute `unique` and `has_duplicates` when `storeValues` is false.
+  has_duplicates?: boolean;
+  unique?: number;
+}
+
+export type ConstantSchemaType = BaseSchemaType & {
+  name: 'Null' | 'Undefined';
+}
 
 export type PrimitiveSchemaType = BaseSchemaType & {
   name: 'String' | 'Number' | 'Int32' | 'Boolean' | 'Decimal128' | 'Long' | 'ObjectId' | 'Date' | 'RegExp' | 'Symbol' | 'MaxKey' | 'MinKey' | 'Binary' | 'Code' | 'Timestamp' | 'DBRef';
@@ -77,7 +81,9 @@ export type DocumentSchemaType = BaseSchemaType & {
   fields: SchemaField[];
 }
 
-export type SchemaType = ConstantSchemaType | PrimitiveSchemaType | ArraySchemaType | DocumentSchemaType;
+// We include the base schema type to make the `semantic-types` usage
+// easier to type.
+export type SchemaType = BaseSchemaType | ConstantSchemaType | PrimitiveSchemaType | ArraySchemaType | DocumentSchemaType;
 
 export type SchemaField = {
   name: string;
@@ -94,27 +100,63 @@ export type Schema = {
   fields: SchemaField[]
 }
 
-// Used when building the end Schema.
-type SchemaBuildingMap = {
-  [typeName: string]: {
-    name: string;
-    path: string;
-    count: number;
-    lengths?: number[];
-    average_length?: number;
-    total_count?: number;
-    types?: SchemaBuildingMap;
+type SchemaBSONType = Exclude<keyof TypeCastMap, 'Object'> | 'Document';
 
-    fields?: SchemaBuildingMap;
-
-    values?: {
-      // Reservoir type.
-      pushSome: (value: any) => void;
-    };
-  }
+type SchemaAnalysisBaseType = {
+  name: string;
+  path: string;
+  bsonType: SchemaBSONType;
+  count: number;
+  values?: ReturnType<typeof Reservoir>
 }
 
-type SemanticTypeFunction = ((value: string, path?: string) => boolean);
+type SchemaAnalysisNullType = SchemaAnalysisBaseType & {
+  name: 'Null';
+}
+
+type SchemaAnalysisPrimitiveType = SchemaAnalysisBaseType & {
+  name: 'String' | 'Number' | 'Int32' | 'Boolean' | 'Decimal128' | 'Long' | 'ObjectId' | 'Date' | 'RegExp' | 'Symbol' | 'MaxKey' | 'MinKey' | 'Binary' | 'Code' | 'Timestamp' | 'DBRef';
+}
+
+type SchemaAnalysisArrayType = SchemaAnalysisBaseType & {
+  name: 'Array';
+  lengths: number[];
+  // eslint-disable-next-line no-use-before-define
+  types: SchemaAnalysisFieldTypes;
+}
+
+type SchemaAnalysisDocumentType = SchemaAnalysisBaseType & {
+  name: 'Document';
+  // eslint-disable-next-line no-use-before-define
+  fields: SchemaAnalysisFieldsMap;
+}
+
+// We include the base schema type to make the `semantic-types` usage
+// easier to type.
+type SchemaAnalysisType = SchemaAnalysisBaseType | SchemaAnalysisNullType | SchemaAnalysisPrimitiveType | SchemaAnalysisArrayType | SchemaAnalysisDocumentType;
+
+type SchemaAnalysisFieldTypes = {
+  [fieldName: string]: SchemaAnalysisType
+}
+
+type SchemaAnalysisField = {
+  name: string;
+  path: string;
+  count: number;
+  types: SchemaAnalysisFieldTypes;
+}
+
+// This is used for the current state of the schema analysis.
+type SchemaAnalysisFieldsMap = {
+  [fieldName: string]: SchemaAnalysisField
+}
+
+type SchemaAnalysisRoot = {
+  fields: SchemaAnalysisFieldsMap;
+  count: number;
+}
+
+type SemanticTypeFunction = ((value: BSONValue, path?: string) => boolean);
 type SemanticTypeMap = {
   [typeName: string]: SemanticTypeFunction | boolean;
 };
@@ -124,16 +166,11 @@ export type SchemaParseOptions = {
   storeValues?: boolean;
 };
 
-export type RootSchema = {
-  fields: SchemaBuildingMap;
-  count: number;
-}
-
 /**
 * Extracts a Javascript string from a BSON type to compute unique values.
 */
 function extractStringValueFromBSON(value: any): string {
-  if (value && value._bsontype) {
+  if (value?._bsontype) {
     if (['Decimal128', 'Long'].includes(value._bsontype)) {
       return value.toString();
     }
@@ -162,148 +199,166 @@ function fieldComparator(a: SchemaField, b: SchemaField) {
 }
 
 /**
- * Final pass through the result to add missing information:
- *   - compute `probability`, `unique`, `has_duplicates` and
- *     `average_length` fields
- *   - add `Undefined` pseudo-types
- *   - collapse `type` arrays to single string if length 1
- *   - turns fields and types objects into arrays to conform with original
- *     schema parser
- * This mutates the passed in schema.
- */
-function finalizeSchema(schema: any, parent?: any, tag?: 'fields' | 'types'): void {
-  if (schema === undefined) {
-    return;
-  }
-
-  if (tag === undefined) {
-    // Recursively finalize fields.
-    // debug('recursively calling schema.fields');
-    finalizeSchema(schema.fields, schema, 'fields');
-  }
-
-  if (tag === 'fields') {
-    Object.values(schema).forEach((field: any) => {
-      // Create `Undefined` pseudo-type.
-      const missing = parent.count - field.count;
-      if (missing > 0) {
-        field.types.Undefined = {
-          name: 'Undefined',
-          type: 'Undefined',
-          path: field.path,
-          count: missing
-        };
-      }
-      field.total_count = Object.values(field.types)
-        .map((v: any) => v.count)
-        .reduce((p, c) => p + c, 0);
-
-      // Recursively finalize types.
-      finalizeSchema(field.types, field, 'types');
-      field.type = field.types.map((v: SchemaField) => v.name);
-      if (field.type.length === 1) {
-        field.type = field.type[0];
-      }
-
-      // A field has duplicates when any of its types have duplicates.
-      field.has_duplicates = !!field.types.find((v: SchemaField) => v.has_duplicates);
-
-      // Compute probability.
-      field.probability = field.count / parent.count;
-    });
-
-    // turn object into array
-    parent.fields = Object.values(parent.fields as SchemaField[]).sort(fieldComparator);
-  }
-
-  if (tag === 'types') {
-    Object.values(schema).forEach((type: any) => {
-      type.total_count = (type.lengths || []).reduce((p: number, c: number) => p + c || 0, 0);
-
-      // debug('recursively calling schema.fields');
-      finalizeSchema(type.fields, type, 'fields');
-
-      // debug('recursively calling schema.types');
-      finalizeSchema(type.types, type, 'types');
-
-      // compute `probability` for each type
-      type.probability = type.count / (parent.total_count || parent.count);
-
-      // compute `unique` and `has_duplicates` for each type
-      if (type.name === 'Null' || type.name === 'Undefined') {
-        delete type.values;
-        type.unique = type.count === 0 ? 0 : 1;
-        type.has_duplicates = type.count > 1;
-      } else if (type.values) {
-        type.unique = new Set(type.values.map(extractStringValueFromBSON)).size;
-        type.has_duplicates = type.unique !== type.values.length;
-      }
-
-      // compute `average_length` for array types
-      if (type.lengths) {
-        type.average_length = type.total_count / type.lengths.length;
-      }
-      // recursively finalize fields and types
-    });
-
-    parent.types = Object.values(parent.types as SchemaType[]).sort((a, b) => b.probability - a.probability);
-  }
-}
-
-/**
  * Returns the type of value as a string. BSON type aware. Replaces `Object`
  * with `Document` to avoid naming conflicts with javascript Objects.
  */
-function getBSONType(value: any): string {
-  let T;
-  if (value && value._bsontype) {
-    T = value._bsontype;
-  } else {
-    T = Object.prototype.toString.call(value).replace(/^\[object (\w+)\]$/, '$1');
+function getBSONType(value: any): SchemaBSONType {
+  const bsonType = value?._bsontype
+    ? value._bsontype
+    : Object.prototype.toString.call(value).replace(/^\[object (\w+)\]$/, '$1');
+
+  if (bsonType === 'Object') {
+    // In the resulting schema we rename `Object` to `Document`.
+    return 'Document';
   }
-  if (T === 'Object') {
-    T = 'Document';
+  return bsonType;
+}
+
+function isNullType(type: SchemaAnalysisType): type is SchemaAnalysisNullType {
+  return (<SchemaAnalysisNullType>type).name === 'Null';
+}
+
+function isArrayType(type: SchemaAnalysisType): type is SchemaAnalysisArrayType {
+  return (<SchemaAnalysisArrayType>type).name === 'Array';
+}
+
+function isDocumentType(type: SchemaAnalysisType): type is SchemaAnalysisDocumentType {
+  return (<SchemaAnalysisDocumentType>type).name === 'Document';
+}
+
+function cropStringAt10kCharacters(value: string) {
+  return value.charCodeAt(10000 - 1) === value.codePointAt(10000 - 1)
+    ? value.slice(0, 10000)
+    : value.slice(0, 10000 - 1);
+}
+
+function computeHasDuplicatesForType(type: SchemaAnalysisType, unique?: number) {
+  if (isNullType(type)) {
+    return type.count > 0;
   }
-  return T;
+
+  if (!type.values) {
+    return undefined;
+  }
+
+  return unique !== type.values.length;
+}
+
+function computeUniqueForType(type: SchemaAnalysisType) {
+  if (isNullType(type)) {
+    return type.count === 0 ? 0 : 1;
+  }
+
+  if (!type.values) {
+    return undefined;
+  }
+
+  // As `values` is from a sample reservoir this isn't a true check for uniqueness.
+  return new Set(type.values.map(extractStringValueFromBSON)).size;
 }
 
 /**
- * Handles adding the value to the value reservoir. Will also crop
- * strings at 10,000 characters.
- *
- * @param {Object} type    the type object from `addToType`
- * @param {Any}    value   the value to be added to `type.values`
+ * Final pass through the result to add missing information:
+ *   - Compute `probability`, `unique`, `has_duplicates` and
+ *     `average_length` fields.
+ *   - Add `Undefined` pseudo-types.
+ *   - Collapse `type` arrays to single string if length 1.
+ *   - Turn fields and types objects into arrays to conform with original
+ *     schema parser.
  */
-function addToValue(type: SchemaBuildingMap[string], value: any) {
-  if (type.name === 'String') {
-    // Crop strings at 10k characters,
-    if (value.length > 10000) {
-      value = value.charCodeAt(10000 - 1) === value.codePointAt(10000 - 1)
-        ? value.slice(0, 10000)
-        : value.slice(0, 10000 - 1);
-    }
+function finalizeSchema(schemaAnalysis: SchemaAnalysisRoot): SchemaField[] {
+  function finalizeArrayFieldProperties(type: SchemaAnalysisArrayType) {
+    const total_count = Object.values(type.types)
+      .map((v: any) => v.count)
+      .reduce((p, c) => p + c, 0);
+
+    const types = finalizeSchemaFieldTypes(type.types, total_count);
+
+    return {
+      types,
+      total_count,
+      lengths: type.lengths,
+      average_length: total_count / type.lengths.length
+    };
   }
-  type.values!.pushSome(value);
+
+  function finalizeSchemaFieldTypes(types: SchemaAnalysisFieldTypes, parentCount: number): SchemaType[] {
+    return Object.values(types).map((type) => {
+      const unique = computeUniqueForType(type);
+
+      return {
+        name: type.name,
+        path: type.path,
+        count: type.count,
+        probability: type.count / parentCount,
+        unique,
+        has_duplicates: computeHasDuplicatesForType(type, unique),
+        values: isNullType(type) ? undefined : type.values,
+        bsonType: type.bsonType, // Note: `Object` is replaced with `Document`.
+        ...(isArrayType(type) ? finalizeArrayFieldProperties(type) : {}),
+        ...(isDocumentType(type) ? { fields: finalizeDocumentFieldSchema(type.fields, type.count) } : {})
+      };
+    }).sort((a, b) => b.probability - a.probability);
+  }
+
+  function finalizeDocumentFieldSchema(fieldMap: SchemaAnalysisFieldsMap, parentCount: number): SchemaField[] {
+    return Object.values(fieldMap).map((field: SchemaAnalysisField): SchemaField => {
+      const fieldTypes = finalizeSchemaFieldTypes(field.types, parentCount);
+
+      const undefinedCount = parentCount - field.count;
+      if (undefinedCount > 0) {
+        // Add the `Undefined` pseudo-type.
+        fieldTypes.push({
+          name: 'Undefined',
+          bsonType: 'Undefined',
+          unique: undefinedCount > 1 ? 0 : 1,
+          has_duplicates: undefinedCount > 1,
+          path: field.path,
+          count: undefinedCount,
+          probability: undefinedCount / parentCount
+        });
+      }
+
+      return {
+        name: field.name,
+        path: field.path,
+        count: field.count,
+        type: fieldTypes.length === 1 ? fieldTypes[0].name : fieldTypes.map((v: SchemaType) => v.name), // Or one value or array.
+        probability: field.count / parentCount,
+        has_duplicates: !!fieldTypes.find((v: SchemaType) => v.has_duplicates),
+        types: fieldTypes
+      };
+    }).sort(fieldComparator);
+  }
+
+  return finalizeDocumentFieldSchema(schemaAnalysis.fields, schemaAnalysis.count);
 }
 
 export class SchemaAnalyzer {
-  finalized: boolean;
   semanticTypes: SemanticTypeMap;
-  rootSchema: RootSchema;
   options: SchemaParseOptions;
+  documentsAnalyzed = 0;
+  schemaAnalysisRoot: SchemaAnalysisRoot = {
+    fields: {},
+    count: 0
+  };
+
+  finalized = true;
+  schemaResult: Schema = {
+    count: 0,
+    fields: []
+  };
 
   constructor(options?: SchemaParseOptions) {
     // Set default options.
     this.options = { semanticTypes: false, storeValues: true, ...options };
 
-    this.finalized = false;
-
     this.semanticTypes = {
-      ...semanticTypeRegisters
+      ...semanticTypes
     };
 
     if (typeof this.options.semanticTypes === 'object') {
-      // enable existing types that evaluate to true
+      // Enable existing semantic types that evaluate to true.
       const enabledTypes = Object.entries(this.options.semanticTypes)
         .filter(([, v]) => typeof v === 'boolean' && v)
         .map(([k]) => k.toLowerCase());
@@ -320,16 +375,10 @@ export class SchemaAnalyzer {
           this.semanticTypes[k] = v;
         });
     }
-
-    this.rootSchema = {
-      fields: {},
-      count: 0
-    };
   }
 
-  getSemanticType(value: any, path: string) {
+  getSemanticType(value: BSONValue, path: string) {
     // Pass value to semantic type detectors, return first match or undefined.
-
     const returnValue = Object.entries(this.semanticTypes)
       .filter(([, v]) => {
         return (v as SemanticTypeFunction)(value, path);
@@ -339,89 +388,89 @@ export class SchemaAnalyzer {
     return returnValue;
   }
 
-  /**
-   * Takes a field value, determines the correct type, handles recursion into
-   * nested arrays and documents, and passes the value down to `addToValue`.
-   *
-   * @param {String}  path     field path in dot notation
-   * @param {Any}     value    value of the field
-   * @param {Object}  schema   the updated schema object
-   */
+  analyzeDoc(doc: Document) {
+    this.finalized = false;
+    /**
+     * Takes a field value, determines the correct type, handles recursion into
+     * nested arrays and documents, and passes the value down to `addToValue`.
+     * Note: This mutates the `schema` argument.
+     */
+    const addToType = (path: string, value: BSONValue, schema: SchemaAnalysisFieldTypes) => {
+      const bsonType = getBSONType(value);
+      // If semantic type detection is enabled, the type is the semantic type
+      // or the original bson type if no semantic type was detected. If disabled,
+      // it is always the bson type.
+      const typeName = (this.options.semanticTypes) ? this.getSemanticType(value, path) || bsonType : bsonType;
+      if (!schema[typeName]) {
+        schema[typeName] = {
+          name: typeName,
+          bsonType: bsonType,
+          path: path,
+          count: 0
+        };
+      }
+      const type = schema[typeName];
+      type.count++;
 
-  addToType(path: string, value: any, schema: SchemaBuildingMap) {
-    const bsonType = getBSONType(value);
-    // If semantic type detection is enabled, the type is the semantic type
-    // or the original bson type if no semantic type was detected. If disabled,
-    // it is always the bson type.
-    const typeName = (this.options.semanticTypes) ? this.getSemanticType(value, path) || bsonType : bsonType;
-    const type = schema[typeName] = _.get(schema, typeName, {
-      name: typeName,
-      bsonType: bsonType,
-      path: path,
-      count: 0
-    } as SchemaBuildingMap[string]);
-    type.count++;
+      if (isArrayType(type)) {
+        // Recurse into arrays by calling `addToType` for each element.
+        type.types = type.types ?? {};
+        type.lengths = type.lengths ?? [];
+        type.lengths.push((value as BSONValue[]).length);
+        (value as BSONValue[]).forEach((v: BSONValue) => addToType(path, v, type.types));
+      } else if (isDocumentType(type)) {
+        // Recurse into nested documents by calling `addToField` for all sub-fields.
+        type.fields = type.fields ?? {};
+        Object.entries(value as Document).forEach(([k, v]) => addToField(`${path}.${k}`, v, type.fields));
+      } else if (this.options.storeValues && !isNullType(type)) {
+        // When the `storeValues` option is enabled, store some example values.
+        if (!type.values) {
+          type.values = bsonType === 'String'
+            ? Reservoir(100) : Reservoir(10000);
+        }
 
-    // Recurse into arrays by calling `addToType` for each element.
-    if (typeName === 'Array') {
-      type.types = type.types ?? {};
-      type.lengths = type.lengths || [];
-      type.lengths.push(value.length);
-      value.forEach((v: SchemaBuildingMap) => this.addToType(path, v, type.types!));
-
-    // Recurse into nested documents by calling `addToField` for all sub-fields.
-    } else if (typeName === 'Document') {
-      type.fields = _.get(type, 'fields', {});
-      Object.entries(value).forEach(([k, v]) => this.addToField(`${path}.${k}`, v, type.fields!));
-
-    // If the `storeValues` option is enabled, store some example values.
-    } else if (this.options.storeValues) {
-      const defaultValue = bsonType === 'String'
-        ? Reservoir(100) : Reservoir(10000);
-      type.values = type.values || defaultValue;
-
-      addToValue(type, value);
-    }
-  }
-
-  /**
-   * Handles a field from a document. Passes the value to `addToType`.
-   *
-   * @param {String}  path     field path in dot notation
-   * @param {Any}     value    value of the field
-   * @param {Object}  schema   the updated schema object
-   */
-  addToField(path: string, value: any, schema: SchemaBuildingMap) {
-    const pathSplitOnDot = path.split('.');
-    const defaults = {
-      [path]: {
-        name: pathSplitOnDot[pathSplitOnDot.length - 1],
-        path: path,
-        count: 0,
-        types: {}
+        type.values.pushSome(
+          type.name === 'String' ? cropStringAt10kCharacters(value as string) : value
+        );
       }
     };
-    _.defaultsDeep(schema, defaults);
-    const field = schema[path];
 
-    field.count++;
-    // debug('added to field', field);
-    this.addToType(path, value, field.types!);
-  }
+    /**
+     * Handles a field from a document. Passes the value to `addToType`.
+     * Note: This mutates the `schema` argument.
+     */
+    const addToField = (path: string, value: BSONValue, schema: SchemaAnalysisFieldsMap) => {
+      if (!schema[path]) {
+        schema[path] = {
+          name: path.split('.')?.pop() || path,
+          path: path,
+          count: 0,
+          types: {}
+        };
+      }
+      const field = schema[path];
 
-  analyzeDoc(doc: Document) {
+      field.count++;
+      addToType(path, value, field.types);
+    };
+
     for (const key of Object.keys(doc)) {
-      this.addToField(key, doc[key], this.rootSchema.fields);
+      addToField(key, doc[key], this.schemaAnalysisRoot.fields);
     }
-    this.rootSchema.count += 1;
+    this.schemaAnalysisRoot.count += 1;
   }
 
-  getResult(): RootSchema {
-    if (!this.finalized) {
-      finalizeSchema(this.rootSchema as SchemaBuildingMap[string]);
-      this.finalized = true;
+  getResult(): Schema {
+    if (this.finalized) {
+      return this.schemaResult;
     }
 
-    return this.rootSchema;
+    this.schemaResult = {
+      count: this.schemaAnalysisRoot.count,
+      fields: finalizeSchema(this.schemaAnalysisRoot)
+    };
+
+    this.finalized = true;
+    return this.schemaResult;
   }
 }

--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -215,15 +215,15 @@ function getBSONType(value: any): SchemaBSONType {
 }
 
 function isNullType(type: SchemaAnalysisType): type is SchemaAnalysisNullType {
-  return (<SchemaAnalysisNullType>type).name === 'Null';
+  return (type as SchemaAnalysisNullType).name === 'Null';
 }
 
 function isArrayType(type: SchemaAnalysisType): type is SchemaAnalysisArrayType {
-  return (<SchemaAnalysisArrayType>type).name === 'Array';
+  return (type as SchemaAnalysisArrayType).name === 'Array';
 }
 
 function isDocumentType(type: SchemaAnalysisType): type is SchemaAnalysisDocumentType {
-  return (<SchemaAnalysisDocumentType>type).name === 'Document';
+  return (type as SchemaAnalysisDocumentType).name === 'Document';
 }
 
 function cropStringAt10kCharacters(value: string) {

--- a/src/semantic-types/email.ts
+++ b/src/semantic-types/email.ts
@@ -1,6 +1,6 @@
 // from http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
 const emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 
-export function isEmail(value: string) {
+export function isEmail(value: any) {
   return emailRegex.test(value);
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -29,7 +29,6 @@ export class ParseStream extends Duplex {
   }
 }
 
-// for backwards compatibility
 export default function makeParseStream(options?: SchemaParseOptions) {
   return new ParseStream(options);
 }

--- a/test/all-bson-types.test.ts
+++ b/test/all-bson-types.test.ts
@@ -1,0 +1,103 @@
+import {
+  BSONRegExp,
+  Binary,
+  Code,
+  DBRef,
+  Decimal128,
+  Double,
+  Int32,
+  Long,
+  MaxKey,
+  MinKey,
+  ObjectId,
+  Timestamp,
+  UUID,
+  BSONSymbol
+} from 'bson';
+import assert from 'assert';
+
+import type { Schema } from '../src/schema-analyzer';
+import getSchema from '../src';
+
+const allBsonTypes = [
+  {
+    _id: new ObjectId('642d766b7300158b1f22e972'),
+    double: new Double(1.2), // Double, 1, double
+    string: 'Hello, world!', // String, 2, string
+    object: { key: 'value' }, // Object, 3, object
+    array: [1, 2, 3], // Array, 4, array
+    binData: new Binary(Buffer.from([1, 2, 3])), // Binary data, 5, binData
+    // Undefined, 6, undefined (deprecated)
+    objectId: new ObjectId('642d766c7300158b1f22e975'), // ObjectId, 7, objectId
+    boolean: true, // Boolean, 8, boolean
+    date: new Date('2023-04-05T13:25:08.445Z'), // Date, 9, date
+    null: null, // Null, 10, null
+    regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
+    // DBPointer, 12, dbPointer (deprecated)
+    javascript: new Code('function() {}'), // JavaScript, 13, javascript
+    symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
+    javascriptWithScope: new Code('function() {}', { foo: 1, bar: 'a' }), // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
+    int: new Int32(12345), // 32-bit integer, 16, "int"
+    timestamp: new Timestamp(new Long('7218556297505931265')), // Timestamp, 17, timestamp
+    long: new Long('123456789123456789'), // 64-bit integer, 18, long
+    decimal: new Decimal128(
+      Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    ), // Decimal128, 19, decimal
+    minKey: new MinKey(), // Min key, -1, minKey
+    maxKey: new MaxKey(), // Max key, 127, maxKey
+
+    binaries: {
+      generic: new Binary(Buffer.from([1, 2, 3]), 0), // 0
+      functionData: new Binary('//8=', 1), // 1
+      binaryOld: new Binary('//8=', 2), // 2
+      uuidOld: new Binary('c//SZESzTGmQ6OfR38A11A==', 3), // 3
+      uuid: new UUID('AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA'), // 4
+      md5: new Binary('c//SZESzTGmQ6OfR38A11A==', 5), // 5
+      encrypted: new Binary('c//SZESzTGmQ6OfR38A11A==', 6), // 6
+      compressedTimeSeries: new Binary('c//SZESzTGmQ6OfR38A11A==', 7), // 7
+      custom: new Binary('//8=', 128) // 128
+    },
+
+    dbRef: new DBRef('namespace', new ObjectId('642d76b4b7ebfab15d3c4a78')) // not actually a separate type, just a convention
+  }
+];
+
+describe('using a document with all bson types', function() {
+  let schema: Schema;
+  before(async function() {
+    schema = await getSchema(allBsonTypes);
+  });
+
+  it('contains all of the types', function() {
+    assert.equal(schema.count, 1);
+
+    const fieldTypes = [
+      'Array',
+      'Binary',
+      'Boolean',
+      'Code',
+      'Date',
+      'Decimal128',
+      'Double',
+      'Int32',
+      'Long',
+      'MaxKey',
+      'MinKey',
+      'Null',
+      'Document',
+      'ObjectId',
+      'BSONRegExp',
+      'String',
+      'BSONSymbol',
+      'Timestamp'
+    ];
+
+    for (const type of fieldTypes) {
+      assert.equal(
+        !!schema.fields.find(schemaField => schemaField.type === type),
+        true,
+        `Cannot find type "${type}" in schemaField types: ${JSON.stringify(schema.fields, null, 2)}`
+      );
+    }
+  });
+});

--- a/test/time-testing.ts
+++ b/test/time-testing.ts
@@ -1,0 +1,39 @@
+/* eslint no-console: 0 */
+
+import { MongoClient } from 'mongodb';
+
+import parseSchema from '../src';
+
+const dbName = 'test';
+const collectionName = 'test-schema';
+// const collectionName = 'complex';
+// const collectionName = 'listings';
+// const collectionName = 'all-bson-types';
+
+const namespace = `${dbName}.${collectionName}`;
+
+const client = new MongoClient(`mongodb://localhost:27017/${dbName}`);
+
+async function run() {
+  const db = client.db(dbName);
+
+  try {
+    const docsLimit = 10000;
+    const docs = await db.collection(collectionName).find().limit(docsLimit).toArray();
+
+    console.log(`Analyzing the schema of ${docs.length} documents from the '${namespace}' namespace...`);
+
+    const startTime = Date.now();
+
+    await parseSchema(docs, {});
+
+    const elapsed = Date.now() - startTime;
+    console.log(`Done. Time elapsed: ${elapsed} ms.`);
+  } catch (err) {
+    return console.error(err);
+  } finally {
+    await client.close();
+  }
+}
+
+run();


### PR DESCRIPTION
Most main changes are in [src/schema-analyzer.ts](https://github.com/mongodb-js/mongodb-schema/compare/COMPASS-6720-update-schema-types?expand=1#diff-014a95a710306ef85390ea1408c13c1a7434e25c418fc4ad94a372d9f00df729) which it looks like GitHub is minimizing by default.

We now export the various types so places like compass-schema and import-export can use them. In a follow up pr we'll move the [`gather-fields`](https://github.com/mongodb-js/compass/blob/main/packages/compass-import-export/src/export/gather-fields.ts) function from `compass-import-export` here so other places can use it (like in the wizard in compass-aggregations). https://github.com/mongodb-js/compass/blob/main/packages/compass-import-export/src/export/gather-fields.ts

These changes are a speedup, mostly from not repeating sorting on every child of a nested document.
Analyzing 10000 documents from the [`listings` fixture](https://github.com/mongodb-js/compass/blob/main/packages/compass-e2e-tests/fixtures/listings.csv.gz) from `compass-e2e-tests`: `270 ms` before, `113 ms` after

Questions/Notes for reviewers:
- [x] Should we update the `snake_case` variable names in the schema output to `camelCase`? It would make these changes a major version, which is fine. `total_count`, `average_length`, and `has_duplicates`. **Yes, let's do it in a separate pr as it involves some README updates.**