### PR TITLE
feat: add getSchemaPaths helper

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -9,8 +9,12 @@ import type { SchemaParseOptions } from './schema-analyzer';
 
 export class ParseStream extends Duplex {
   analyzer: SchemaAnalyzer;
-  constructor(options?: SchemaParseOptions) {
+  schemaPaths = false;
+  constructor(options?: SchemaParseOptions & {
+    schemaPaths?: boolean;
+  }) {
     super({ objectMode: true });
+    this.schemaPaths = !!options?.schemaPaths;
     this.analyzer = new SchemaAnalyzer(options);
   }
 
@@ -23,12 +27,18 @@ export class ParseStream extends Duplex {
   _read() {}
 
   _final(cb: () => void) {
-    this.push(this.analyzer.getResult());
+    if (this.schemaPaths) {
+      this.push(this.analyzer.getSchemaPaths());
+    } else {
+      this.push(this.analyzer.getResult());
+    }
     this.push(null);
     cb();
   }
 }
 
-export default function makeParseStream(options?: SchemaParseOptions) {
+export default function makeParseStream(options?: SchemaParseOptions & {
+    schemaPaths?: boolean;
+  }) {
   return new ParseStream(options);
 }

--- a/test/get-schema-paths.test.ts
+++ b/test/get-schema-paths.test.ts
@@ -1,10 +1,12 @@
 import assert from 'assert';
+import type { Document } from 'bson';
 
 import { getSchemaPaths } from '../src';
 
 describe('getSchemaPaths', function() {
+  let schemaPaths: string[][];
+
   describe('with fields with dots in them', function() {
-    let schemaPaths: string[][];
     const docs = [
       {
         pineapple: {
@@ -34,7 +36,6 @@ describe('getSchemaPaths', function() {
   });
 
   describe('with multiple documents with different fields', function() {
-    let schemaPaths: string[][];
     const docs = [
       {
         pineapple: {
@@ -69,7 +70,6 @@ describe('getSchemaPaths', function() {
   });
 
   describe('with nested array documents', function() {
-    let schemaPaths: string[][];
     const docs = [
       {
         orangutan: [{
@@ -94,6 +94,18 @@ describe('getSchemaPaths', function() {
         ['orangutan', 'lizard', 'snakes'],
         ['orangutan', 'lizard', 'birds']
       ]);
+    });
+  });
+
+  describe('with no documents', function() {
+    const docs: Document[] = [];
+
+    before(async function() {
+      schemaPaths = await getSchemaPaths(docs);
+    });
+
+    it('returns no paths', function() {
+      assert.deepEqual(schemaPaths, []);
     });
   });
 });

--- a/test/get-schema-paths.test.ts
+++ b/test/get-schema-paths.test.ts
@@ -1,0 +1,99 @@
+import assert from 'assert';
+
+import { getSchemaPaths } from '../src';
+
+describe('getSchemaPaths', function() {
+  describe('with fields with dots in them', function() {
+    let schemaPaths: string[][];
+    const docs = [
+      {
+        pineapple: {
+          orange: {
+            apple: 1
+          },
+          'orange.with.dot': {
+            bah: 2
+          }
+        }
+      }
+    ];
+
+    before(async function() {
+      schemaPaths = await getSchemaPaths(docs);
+    });
+
+    it('returns an array of the fields', function() {
+      assert.deepEqual(schemaPaths, [
+        ['pineapple'],
+        ['pineapple', 'orange'],
+        ['pineapple', 'orange', 'apple'],
+        ['pineapple', 'orange.with.dot'],
+        ['pineapple', 'orange.with.dot', 'bah']
+      ]);
+    });
+  });
+
+  describe('with multiple documents with different fields', function() {
+    let schemaPaths: string[][];
+    const docs = [
+      {
+        pineapple: {
+          orange: {
+            apple: 1
+          }
+        }
+      },
+      {
+        pineapple: {
+          orange: 'ok'
+        }
+      },
+      {
+        pineapple: ['test', '123'],
+        clementine: false
+      }
+    ];
+
+    before(async function() {
+      schemaPaths = await getSchemaPaths(docs);
+    });
+
+    it('returns all of the field paths', function() {
+      assert.deepEqual(schemaPaths, [
+        ['pineapple'],
+        ['pineapple', 'orange'],
+        ['pineapple', 'orange', 'apple'],
+        ['clementine']
+      ]);
+    });
+  });
+
+  describe('with nested array documents', function() {
+    let schemaPaths: string[][];
+    const docs = [
+      {
+        orangutan: [{
+          tuatara: 'yes',
+          lizard: {
+            snakes: false,
+            birds: false
+          }
+        }]
+      }
+    ];
+
+    before(async function() {
+      schemaPaths = await getSchemaPaths(docs);
+    });
+
+    it('returns all of the field paths', function() {
+      assert.deepEqual(schemaPaths, [
+        ['orangutan'],
+        ['orangutan', 'tuatara'],
+        ['orangutan', 'lizard'],
+        ['orangutan', 'lizard', 'snakes'],
+        ['orangutan', 'lizard', 'birds']
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This is something we already have in Compass that we're moving here. Here's where it was in Compass (after merging and releasing this pr we'll remove it in Compass and start using it from this package): https://github.com/mongodb-js/compass/blob/892e83129ea3a33ba42c1fc1f5f094b45fd17885/packages/compass-import-export/src/export/gather-fields.ts#L36

This should also speed up how we do it in Compass as we don't need to finalize the schema to get the schema paths. The overload on the options in the `stream` file is a big gross, open to suggestions on how to make this a bit cleaner.