### PR TITLE
chore(testing): remove node 14, add node 20 for github workflow tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
So we can use `stream/promises` in https://github.com/mongodb-js/mongodb-schema/pull/192