### PR TITLE
feat: sort paths from getSchemaPaths

### DIFF
--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -183,7 +183,11 @@ function extractStringValueFromBSON(value: any): string {
   return String(value);
 }
 
-function fieldComparator(a: SchemaField, b: SchemaField) {
+function fieldComparator(a: {
+  name: string
+}, b: {
+  name: string
+}) {
   // Make sure _id is always at top, even in presence of uppercase fields.
   const aName = a.name;
   const bName = b.name;
@@ -233,8 +237,9 @@ function schemaToPaths(
   parent: string[] = []
 ): string[][] {
   const paths: string[][] = [];
+  const sortedFields = Object.values(fields).sort(fieldComparator);
 
-  for (const field of Object.values(fields)) {
+  for (const field of sortedFields) {
     const path = [...parent, field.name];
     paths.push(path);
 

--- a/test/get-schema-paths.test.ts
+++ b/test/get-schema-paths.test.ts
@@ -59,12 +59,12 @@ describe('getSchemaPaths', function() {
       schemaPaths = await getSchemaPaths(docs);
     });
 
-    it('returns all of the field paths', function() {
+    it('returns all of the field paths (sorted)', function() {
       assert.deepEqual(schemaPaths, [
+        ['clementine'],
         ['pineapple'],
         ['pineapple', 'orange'],
-        ['pineapple', 'orange', 'apple'],
-        ['clementine']
+        ['pineapple', 'orange', 'apple']
       ]);
     });
   });
@@ -86,13 +86,13 @@ describe('getSchemaPaths', function() {
       schemaPaths = await getSchemaPaths(docs);
     });
 
-    it('returns all of the field paths', function() {
+    it('returns all of the field paths (sorted)', function() {
       assert.deepEqual(schemaPaths, [
         ['orangutan'],
-        ['orangutan', 'tuatara'],
         ['orangutan', 'lizard'],
+        ['orangutan', 'lizard', 'birds'],
         ['orangutan', 'lizard', 'snakes'],
-        ['orangutan', 'lizard', 'birds']
+        ['orangutan', 'tuatara']
       ]);
     });
   });


### PR DESCRIPTION
Compass assumes these are sorted, I'm thinking it's easier to have this here than in any consumers of this package/function, but if folks feel differently we can not merge this. No strong preference.

Will make this a minor.