### PR TITLE
feat: add getSimplifiedSchema helper which returns a schema without any metadata COMPASS-6979

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ below accordingly).
 3. Create a new file `parse-schema.js` and paste in the following code:
 
     ```javascript
-    const { default: parseSchema } = require('mongodb-schema');
+    const { parseSchema } = require('mongodb-schema');
     const { MongoClient } = require('mongodb');
 
     const dbName = 'test';

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ below accordingly).
 3. Create a new file `parse-schema.js` and paste in the following code:
 
     ```javascript
-    const parseSchema = require('mongodb-schema');
+    const { default: parseSchema } = require('mongodb-schema');
     const { MongoClient } = require('mongodb');
 
     const dbName = 'test';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Readable, PassThrough } from 'stream';
 import { pipeline } from 'stream/promises';
 
 import stream from './stream';
+import type { ParseStreamOptions } from './stream';
 import { SchemaAnalyzer } from './schema-analyzer';
 import type {
   ArraySchemaType,
@@ -48,6 +49,20 @@ function getStreamSource(
   return streamSource;
 }
 
+async function schemaStream(
+  source: Document[] | MongoDBCursor | Readable,
+  options?: ParseStreamOptions
+) {
+  const streamSource = getStreamSource(source);
+
+  const dest = new PassThrough({ objectMode: true });
+  await pipeline(streamSource, stream(options), dest);
+  for await (const result of dest) {
+    return result;
+  }
+  throw new Error('unreachable'); // `dest` always emits exactly one doc.
+}
+
 /**
  * Convenience shortcut for parsing schemas. Accepts an array, stream or
  * MongoDB cursor object to parse documents` from.
@@ -56,51 +71,25 @@ async function parseSchema(
   source: Document[] | MongoDBCursor | Readable,
   options?: SchemaParseOptions
 ): Promise<Schema> {
-  // Shift parameters if no options are specified.
-  if (typeof options === 'undefined') {
-    options = {};
-  }
-
-  const streamSource = getStreamSource(source);
-
-  const dest = new PassThrough({ objectMode: true });
-  await pipeline(streamSource, stream(options), dest);
-  for await (const result of dest) {
-    return result;
-  }
-  throw new Error('unreachable'); // `dest` always emits one doc.
+  return await schemaStream(source, options);
 }
 
 // Convenience shortcut for getting schema paths.
 async function getSchemaPaths(
   source: Document[] | MongoDBCursor | Readable
 ): Promise<string[][]> {
-  const streamSource = getStreamSource(source);
-
-  const dest = new PassThrough({ objectMode: true });
-  await pipeline(streamSource, stream({
+  return await schemaStream(source, {
     schemaPaths: true
-  }), dest);
-  for await (const result of dest) {
-    return result;
-  }
-  throw new Error('unreachable'); // `dest` always emits one doc.
+  });
 }
 
 // Convenience shortcut for getting the simplified schema.
 async function getSimplifiedSchema(
   source: Document[] | MongoDBCursor | Readable
 ): Promise<SimplifiedSchema> {
-  const streamSource = getStreamSource(source);
-
-  const dest = new PassThrough({ objectMode: true });
-  await pipeline(streamSource, stream({
+  return await schemaStream(source, {
     simplifiedSchema: true
-  }), dest);
-  for await (const result of dest) {
-    return result;
-  }
-  throw new Error('unreachable'); // `dest` always emits one doc.
+  });
 }
 
 export default parseSchema;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,13 @@ import type {
   SchemaType,
   Schema,
   SchemaField,
-  SchemaParseOptions
+  SchemaParseOptions,
+  SimplifiedSchemaBaseType,
+  SimplifiedSchemaArrayType,
+  SimplifiedSchemaDocumentType,
+  SimplifiedSchemaType,
+  SimplifiedSchemaField,
+  SimplifiedSchema
 } from './schema-analyzer';
 import * as schemaStats from './stats';
 
@@ -81,6 +87,22 @@ async function getSchemaPaths(
   throw new Error('unreachable'); // `dest` always emits one doc.
 }
 
+// Convenience shortcut for getting the simplified schema.
+async function getSimplifiedSchema(
+  source: Document[] | MongoDBCursor | Readable
+): Promise<SimplifiedSchema> {
+  const streamSource = getStreamSource(source);
+
+  const dest = new PassThrough({ objectMode: true });
+  await pipeline(streamSource, stream({
+    simplifiedSchema: true
+  }), dest);
+  for await (const result of dest) {
+    return result;
+  }
+  throw new Error('unreachable'); // `dest` always emits one doc.
+}
+
 export default parseSchema;
 
 export type {
@@ -92,12 +114,20 @@ export type {
   SchemaType,
   Schema,
   SchemaField,
-  SchemaParseOptions
+  SchemaParseOptions,
+  SimplifiedSchemaBaseType,
+  SimplifiedSchemaArrayType,
+  SimplifiedSchemaDocumentType,
+  SimplifiedSchemaType,
+  SimplifiedSchemaField,
+  SimplifiedSchema
 };
 
 export {
   stream,
+  parseSchema,
   getSchemaPaths,
+  getSimplifiedSchema,
   SchemaAnalyzer,
   schemaStats
 };

--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -285,7 +285,6 @@ export type SimplifiedSchemaDocumentType = SimplifiedSchemaBaseType & {
 }
 export type SimplifiedSchemaType = SimplifiedSchemaBaseType | SimplifiedSchemaArrayType | SimplifiedSchemaDocumentType;
 export type SimplifiedSchemaField = {
-  // name: string;
   types: SimplifiedSchemaType[];
 };
 export type SimplifiedSchema = {
@@ -311,7 +310,6 @@ function simplifiedSchema(fields: SchemaAnalysisFieldsMap): SimplifiedSchema {
       const fieldTypes = finalizeSchemaFieldTypes(field.types);
 
       fieldSchema[field.name] = {
-        // name: field.name,
         types: fieldTypes
       };
     });
@@ -576,11 +574,7 @@ export class SchemaAnalyzer {
   }
 
   /**
-   * This returns a simplified schema result which may not tell the whole picture.
-   *
-   * For cases where the schema of different documents differs greatly,
-   * the result of this function will contain a union of the different document's schema
-   * and may omit nested fields when another types exists in most documents.
+   * Returns a simplified schema result, this has no type metadata.
    */
   getSimplifiedSchema(): SimplifiedSchema {
     return simplifiedSchema(this.schemaAnalysisRoot.fields);

--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -270,6 +270,57 @@ function schemaToPaths(
   return paths;
 }
 
+export type SimplifiedSchemaBaseType = {
+  bsonType: SchemaBSONType;
+}
+export type SimplifiedSchemaArrayType = SimplifiedSchemaBaseType & {
+  bsonType: 'Array';
+  // eslint-disable-next-line no-use-before-define
+  types: SimplifiedSchemaType[];
+}
+export type SimplifiedSchemaDocumentType = SimplifiedSchemaBaseType & {
+  bsonType: 'Document';
+  // eslint-disable-next-line no-use-before-define
+  fields: SimplifiedSchema;
+}
+export type SimplifiedSchemaType = SimplifiedSchemaBaseType | SimplifiedSchemaArrayType | SimplifiedSchemaDocumentType;
+export type SimplifiedSchemaField = {
+  // name: string;
+  types: SimplifiedSchemaType[];
+};
+export type SimplifiedSchema = {
+  [fieldName: string]: SimplifiedSchemaField
+}
+
+function simplifiedSchema(fields: SchemaAnalysisFieldsMap): SimplifiedSchema {
+  function finalizeSchemaFieldTypes(types: SchemaAnalysisFieldTypes): SimplifiedSchemaType[] {
+    return Object.values(types).map((type) => {
+      return {
+        bsonType: type.bsonType, // Note: `Object` is replaced with `Document`.
+        ...(isArrayType(type) ? {
+          types: finalizeSchemaFieldTypes(type.types)
+        } : {}),
+        ...(isDocumentType(type) ? { fields: finalizeDocumentFieldSchema(type.fields) } : {})
+      };
+    });
+  }
+
+  function finalizeDocumentFieldSchema(fieldMap: SchemaAnalysisFieldsMap): SimplifiedSchema {
+    const fieldSchema: SimplifiedSchema = {};
+    Object.values(fieldMap).forEach((field: SchemaAnalysisField) => {
+      const fieldTypes = finalizeSchemaFieldTypes(field.types);
+
+      fieldSchema[field.name] = {
+        // name: field.name,
+        types: fieldTypes
+      };
+    });
+    return fieldSchema;
+  }
+
+  return finalizeDocumentFieldSchema(fields);
+}
+
 function cropStringAt10kCharacters(value: string) {
   return value.charCodeAt(10000 - 1) === value.codePointAt(10000 - 1)
     ? value.slice(0, 10000)
@@ -522,5 +573,16 @@ export class SchemaAnalyzer {
 
   getSchemaPaths(): string[][] {
     return schemaToPaths(this.schemaAnalysisRoot.fields);
+  }
+
+  /**
+   * This returns a simplified schema result which may not tell the whole picture.
+   *
+   * For cases where the schema of different documents differs greatly,
+   * the result of this function will contain a union of the different document's schema
+   * and may omit nested fields when another types exists in most documents.
+   */
+  getSimplifiedSchema(): SimplifiedSchema {
+    return simplifiedSchema(this.schemaAnalysisRoot.fields);
   }
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -7,7 +7,7 @@ import type {
 import { SchemaAnalyzer } from './schema-analyzer';
 import type { SchemaParseOptions } from './schema-analyzer';
 
-type ParseStreamOptions = SchemaParseOptions & {
+export type ParseStreamOptions = SchemaParseOptions & {
   simplifiedSchema?: boolean,
   schemaPaths?: boolean;
 };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -7,14 +7,19 @@ import type {
 import { SchemaAnalyzer } from './schema-analyzer';
 import type { SchemaParseOptions } from './schema-analyzer';
 
+type ParseStreamOptions = SchemaParseOptions & {
+  simplifiedSchema?: boolean,
+  schemaPaths?: boolean;
+};
+
 export class ParseStream extends Duplex {
   analyzer: SchemaAnalyzer;
+  options: ParseStreamOptions;
   schemaPaths = false;
-  constructor(options?: SchemaParseOptions & {
-    schemaPaths?: boolean;
-  }) {
+
+  constructor(options?: ParseStreamOptions) {
     super({ objectMode: true });
-    this.schemaPaths = !!options?.schemaPaths;
+    this.options = options || {};
     this.analyzer = new SchemaAnalyzer(options);
   }
 
@@ -27,8 +32,10 @@ export class ParseStream extends Duplex {
   _read() {}
 
   _final(cb: () => void) {
-    if (this.schemaPaths) {
+    if (this.options.schemaPaths) {
       this.push(this.analyzer.getSchemaPaths());
+    } else if (this.options.simplifiedSchema) {
+      this.push(this.analyzer.getSimplifiedSchema());
     } else {
       this.push(this.analyzer.getResult());
     }
@@ -37,8 +44,6 @@ export class ParseStream extends Duplex {
   }
 }
 
-export default function makeParseStream(options?: SchemaParseOptions & {
-    schemaPaths?: boolean;
-  }) {
+export default function makeParseStream(options?: ParseStreamOptions) {
   return new ParseStream(options);
 }

--- a/test/all-bson-types-fixture.ts
+++ b/test/all-bson-types-fixture.ts
@@ -1,0 +1,57 @@
+import {
+  BSONRegExp,
+  Binary,
+  Code,
+  DBRef,
+  Decimal128,
+  Double,
+  Int32,
+  Long,
+  MaxKey,
+  MinKey,
+  ObjectId,
+  Timestamp,
+  UUID,
+  BSONSymbol
+} from 'bson';
+
+export const allBSONTypesDoc = {
+  _id: new ObjectId('642d766b7300158b1f22e972'),
+  double: new Double(1.2), // Double, 1, double
+  string: 'Hello, world!', // String, 2, string
+  object: { key: 'value' }, // Object, 3, object
+  array: [1, 2, 3], // Array, 4, array
+  binData: new Binary(Buffer.from([1, 2, 3])), // Binary data, 5, binData
+  // Undefined, 6, undefined (deprecated)
+  objectId: new ObjectId('642d766c7300158b1f22e975'), // ObjectId, 7, objectId
+  boolean: true, // Boolean, 8, boolean
+  date: new Date('2023-04-05T13:25:08.445Z'), // Date, 9, date
+  null: null, // Null, 10, null
+  regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
+  // DBPointer, 12, dbPointer (deprecated)
+  javascript: new Code('function() {}'), // JavaScript, 13, javascript
+  symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
+  javascriptWithScope: new Code('function() {}', { foo: 1, bar: 'a' }), // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
+  int: new Int32(12345), // 32-bit integer, 16, "int"
+  timestamp: new Timestamp(new Long('7218556297505931265')), // Timestamp, 17, timestamp
+  long: new Long('123456789123456789'), // 64-bit integer, 18, long
+  decimal: new Decimal128(
+    Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+  ), // Decimal128, 19, decimal
+  minKey: new MinKey(), // Min key, -1, minKey
+  maxKey: new MaxKey(), // Max key, 127, maxKey
+
+  binaries: {
+    generic: new Binary(Buffer.from([1, 2, 3]), 0), // 0
+    functionData: new Binary('//8=', 1), // 1
+    binaryOld: new Binary('//8=', 2), // 2
+    uuidOld: new Binary('c//SZESzTGmQ6OfR38A11A==', 3), // 3
+    uuid: new UUID('AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA'), // 4
+    md5: new Binary('c//SZESzTGmQ6OfR38A11A==', 5), // 5
+    encrypted: new Binary('c//SZESzTGmQ6OfR38A11A==', 6), // 6
+    compressedTimeSeries: new Binary('c//SZESzTGmQ6OfR38A11A==', 7), // 7
+    custom: new Binary('//8=', 128) // 128
+  },
+
+  dbRef: new DBRef('namespace', new ObjectId('642d76b4b7ebfab15d3c4a78')) // not actually a separate type, just a convention
+};

--- a/test/all-bson-types.test.ts
+++ b/test/all-bson-types.test.ts
@@ -1,71 +1,13 @@
-import {
-  BSONRegExp,
-  Binary,
-  Code,
-  DBRef,
-  Decimal128,
-  Double,
-  Int32,
-  Long,
-  MaxKey,
-  MinKey,
-  ObjectId,
-  Timestamp,
-  UUID,
-  BSONSymbol
-} from 'bson';
 import assert from 'assert';
 
 import type { Schema } from '../src/schema-analyzer';
 import getSchema from '../src';
-
-const allBsonTypes = [
-  {
-    _id: new ObjectId('642d766b7300158b1f22e972'),
-    double: new Double(1.2), // Double, 1, double
-    string: 'Hello, world!', // String, 2, string
-    object: { key: 'value' }, // Object, 3, object
-    array: [1, 2, 3], // Array, 4, array
-    binData: new Binary(Buffer.from([1, 2, 3])), // Binary data, 5, binData
-    // Undefined, 6, undefined (deprecated)
-    objectId: new ObjectId('642d766c7300158b1f22e975'), // ObjectId, 7, objectId
-    boolean: true, // Boolean, 8, boolean
-    date: new Date('2023-04-05T13:25:08.445Z'), // Date, 9, date
-    null: null, // Null, 10, null
-    regex: new BSONRegExp('pattern', 'i'), // Regular Expression, 11, regex
-    // DBPointer, 12, dbPointer (deprecated)
-    javascript: new Code('function() {}'), // JavaScript, 13, javascript
-    symbol: new BSONSymbol('symbol'), // Symbol, 14, symbol (deprecated)
-    javascriptWithScope: new Code('function() {}', { foo: 1, bar: 'a' }), // JavaScript code with scope 15 "javascriptWithScope" Deprecated in MongoDB 4.4.
-    int: new Int32(12345), // 32-bit integer, 16, "int"
-    timestamp: new Timestamp(new Long('7218556297505931265')), // Timestamp, 17, timestamp
-    long: new Long('123456789123456789'), // 64-bit integer, 18, long
-    decimal: new Decimal128(
-      Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
-    ), // Decimal128, 19, decimal
-    minKey: new MinKey(), // Min key, -1, minKey
-    maxKey: new MaxKey(), // Max key, 127, maxKey
-
-    binaries: {
-      generic: new Binary(Buffer.from([1, 2, 3]), 0), // 0
-      functionData: new Binary('//8=', 1), // 1
-      binaryOld: new Binary('//8=', 2), // 2
-      uuidOld: new Binary('c//SZESzTGmQ6OfR38A11A==', 3), // 3
-      uuid: new UUID('AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA'), // 4
-      md5: new Binary('c//SZESzTGmQ6OfR38A11A==', 5), // 5
-      encrypted: new Binary('c//SZESzTGmQ6OfR38A11A==', 6), // 6
-      compressedTimeSeries: new Binary('c//SZESzTGmQ6OfR38A11A==', 7), // 7
-      custom: new Binary('//8=', 128) // 128
-    },
-
-    dbRef: new DBRef('namespace', new ObjectId('642d76b4b7ebfab15d3c4a78')) // not actually a separate type, just a convention
-  }
-];
+import { allBSONTypesDoc } from './all-bson-types-fixture';
 
 describe('using a document with all bson types', function() {
   let schema: Schema;
   before(async function() {
-    schema = await getSchema(allBsonTypes);
+    schema = await getSchema([allBSONTypesDoc]);
   });
 
   it('contains all of the types', function() {

--- a/test/simplified-schema.test.ts
+++ b/test/simplified-schema.test.ts
@@ -1,0 +1,253 @@
+import assert from 'assert';
+
+import { getSimplifiedSchema } from '../src';
+import type { SimplifiedSchema } from '../src/schema-analyzer';
+import { allBSONTypesDoc } from './all-bson-types-fixture';
+
+const docsFixture = [
+  {
+    foo: 1,
+    bar: 'test'
+  },
+  {
+    foo: 2,
+    bar: 25,
+    baz: true
+  },
+  {
+    foo: 3,
+    bar: 'another test'
+  },
+  allBSONTypesDoc
+];
+
+const expected = {
+  _id: {
+    types: [{
+      bsonType: 'ObjectId'
+    }]
+  },
+  double: {
+    types: [{
+      bsonType: 'Double'
+    }]
+  },
+  string: {
+    types: [{
+      bsonType: 'String'
+    }]
+  },
+  object: {
+    types: [{
+      bsonType: 'Document',
+      fields: {
+        key: {
+          types: [{
+            bsonType: 'String'
+          }]
+        }
+      }
+    }]
+  },
+  array: {
+    types: [{
+      bsonType: 'Array',
+      types: [{
+        bsonType: 'Number'
+      }]
+    }]
+  },
+  binData: {
+    types: [{
+      bsonType: 'Binary'
+    }]
+  },
+  objectId: {
+    types: [{
+      bsonType: 'ObjectId'
+    }]
+  },
+  boolean: {
+    types: [{
+      bsonType: 'Boolean'
+    }]
+  },
+  date: {
+    types: [{
+      bsonType: 'Date'
+    }]
+  },
+  null: {
+    types: [{
+      bsonType: 'Null'
+    }]
+  },
+  regex: {
+    types: [{
+      bsonType: 'BSONRegExp'
+    }]
+  },
+  javascript: {
+    types: [{
+      bsonType: 'Code'
+    }]
+  },
+  symbol: {
+    types: [{
+      bsonType: 'BSONSymbol'
+    }]
+  },
+  javascriptWithScope: {
+    types: [{
+      bsonType: 'Code'
+    }]
+  },
+  int: {
+    types: [{
+      bsonType: 'Int32'
+    }]
+  },
+  timestamp: {
+    types: [{
+      bsonType: 'Timestamp'
+    }]
+  },
+  long: {
+    types: [{
+      bsonType: 'Long'
+    }]
+  },
+  decimal: {
+    types: [{
+      bsonType: 'Decimal128'
+    }]
+  },
+  minKey: {
+    types: [{
+      bsonType: 'MinKey'
+    }]
+  },
+  maxKey: {
+    types: [{
+      bsonType: 'MaxKey'
+    }]
+  },
+
+  binaries: {
+    types: [{
+      bsonType: 'Document',
+      fields: {
+        generic: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        functionData: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        binaryOld: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        uuidOld: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        uuid: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        md5: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        encrypted: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        compressedTimeSeries: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        },
+        custom: {
+          types: [{
+            bsonType: 'Binary'
+          }]
+        }
+      }
+    }]
+  },
+  dbRef: {
+    types: [{
+      bsonType: 'DBRef'
+    }]
+  },
+  foo: {
+    types: [{
+      bsonType: 'Number'
+    }]
+  },
+  bar: {
+    types: [{
+      bsonType: 'String'
+    }, {
+      bsonType: 'Number'
+    }]
+  },
+  baz: {
+    types: [{
+      bsonType: 'Boolean'
+    }]
+  }
+};
+
+describe('simplified schema', function() {
+  let schema: SimplifiedSchema;
+
+  before(async function() {
+    schema = await getSimplifiedSchema(docsFixture);
+  });
+
+  it('should assemble a simplified schema', function() {
+    assert.deepEqual(schema, expected);
+  });
+
+  it('contains all of the types', function() {
+    const fieldTypes = [
+      'Array',
+      'Binary',
+      'Boolean',
+      'Code',
+      'Date',
+      'Decimal128',
+      'Double',
+      'Int32',
+      'Long',
+      'MaxKey',
+      'MinKey',
+      'Null',
+      'Document',
+      'ObjectId',
+      'BSONRegExp',
+      'String',
+      'BSONSymbol',
+      'Timestamp'
+    ];
+
+    for (const fieldType of fieldTypes) {
+      assert.equal(
+        !!Object.values(schema).find(schemaType => schemaType.types.find(schemaType => schemaType.bsonType === fieldType)),
+        true,
+        `Cannot find type "${fieldType}" in schemaField types: ${JSON.stringify(schema.fields, null, 2)}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
COMPASS-6979

Another option instead of adding a separate helper would be to add a lot of logic around an optional in the existing schema parser. This would have added a lot of branching logic, and likely would have made this helper a bit slower. 

This will be used in Compass for generating a schema to pass to the large language model / ai.