### PR TITLE
feat: optional field count threshold

### DIFF
--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -167,6 +167,7 @@ type AllSchemaParseOptions = {
   storeValues: boolean;
   signal?: AbortSignal;
   storedValuesLengthLimit: number;
+  distinctFieldsAbortThreshold?: number;
 };
 export type SchemaParseOptions = Partial<AllSchemaParseOptions>;
 
@@ -469,6 +470,7 @@ export class SchemaAnalyzer {
   semanticTypes: SemanticTypeMap;
   options: AllSchemaParseOptions;
   documentsAnalyzed = 0;
+  fieldsCount = 0;
   schemaAnalysisRoot: SchemaAnalysisRoot = {
     fields: Object.create(null),
     count: 0
@@ -505,6 +507,14 @@ export class SchemaAnalyzer {
         .forEach(([k, v]) => {
           this.semanticTypes[k] = v;
         });
+    }
+  }
+
+  increaseFieldCount() {
+    if (!this.options.distinctFieldsAbortThreshold) return;
+    this.fieldsCount++;
+    if (this.fieldsCount > this.options.distinctFieldsAbortThreshold) {
+      throw new Error(`Schema analysis aborted: Fields count above ${this.options.distinctFieldsAbortThreshold}`);
     }
   }
 
@@ -580,6 +590,7 @@ export class SchemaAnalyzer {
           count: 0,
           types: Object.create(null)
         };
+        this.increaseFieldCount();
       }
       const field = schema[fieldName];
 

--- a/src/schema-analyzer.ts
+++ b/src/schema-analyzer.ts
@@ -167,6 +167,8 @@ type AllSchemaParseOptions = {
   storeValues: boolean;
   signal?: AbortSignal;
   storedValuesLengthLimit: number;
+  /** Complexity limit:
+   * The analysis will be aborted if the threshold is exceeded. */
   distinctFieldsAbortThreshold?: number;
 };
 export type SchemaParseOptions = Partial<AllSchemaParseOptions>;

--- a/test/bloated.test.ts
+++ b/test/bloated.test.ts
@@ -69,5 +69,23 @@ describe('bloated documents', function() {
         assert.strictEqual((error as Error).message, 'Schema analysis aborted: Fields count above 4');
       }
     });
+
+    it('aborts after reaching the given limit - nested', async function() {
+      const documents = [{
+        field1: {
+          field2: {
+            field3: 'abc',
+            field4: 'bca'
+          },
+          field5: 'cab'
+        }
+      }];
+      try {
+        await getSchema(documents, { distinctFieldsAbortThreshold: 4 });
+        assert.fail('Analysis did not throw');
+      } catch (error) {
+        assert.strictEqual((error as Error).message, 'Schema analysis aborted: Fields count above 4');
+      }
+    });
   });
 });

--- a/test/bloated.test.ts
+++ b/test/bloated.test.ts
@@ -14,40 +14,60 @@ function generateRandomString(length: number) {
 }
 
 describe('bloated documents', function() {
-  it('really long string is cropped', async function() {
-    const documents = [{
-      str: generateRandomString(20000)
-    }];
-    const schema = await getSchema(documents);
-    const stringLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as string).length;
-    assert.ok(stringLength <= 10000);
+  describe('sizeable sample values', function() {
+    it('really long string is cropped', async function() {
+      const documents = [{
+        str: generateRandomString(20000)
+      }];
+      const schema = await getSchema(documents);
+      const stringLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as string).length;
+      assert.ok(stringLength <= 10000);
+    });
+
+    it('really long code is cropped', async function() {
+      const documents = [{
+        code: new Code(generateRandomString(20000))
+      }];
+      const schema = await getSchema(documents);
+      const codeLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as Code).code.length;
+      assert.ok(codeLength <= 10000);
+    });
+
+    it('really long binary is cropped', async function() {
+      const documents = [{
+        binData: new Binary(Buffer.from(generateRandomString(20000)), 2)
+      }];
+      const schema = await getSchema(documents);
+      const binary = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as Binary);
+      assert.ok(binary.length() <= 10000);
+      assert.strictEqual(binary.sub_type, 2);
+    });
+
+    it('the limit is configurable', async function() {
+      const documents = [{
+        str: generateRandomString(20000)
+      }];
+      const schema = await getSchema(documents, { storedValuesLengthLimit: 5 });
+      const stringLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as string).length;
+      assert.ok(stringLength === 5);
+    });
   });
 
-  it('really long code is cropped', async function() {
-    const documents = [{
-      code: new Code(generateRandomString(20000))
-    }];
-    const schema = await getSchema(documents);
-    const codeLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as Code).code.length;
-    assert.ok(codeLength <= 10000);
-  });
-
-  it('really long binary is cropped', async function() {
-    const documents = [{
-      binData: new Binary(Buffer.from(generateRandomString(20000)), 2)
-    }];
-    const schema = await getSchema(documents);
-    const binary = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as Binary);
-    assert.ok(binary.length() <= 10000);
-    assert.strictEqual(binary.sub_type, 2);
-  });
-
-  it('the limit is configurable', async function() {
-    const documents = [{
-      str: generateRandomString(20000)
-    }];
-    const schema = await getSchema(documents, { storedValuesLengthLimit: 5 });
-    const stringLength = ((schema.fields[0].types[0] as PrimitiveSchemaType).values[0] as string).length;
-    assert.ok(stringLength === 5);
+  describe('high complexity', function() {
+    it('aborts after reaching the given limit', async function() {
+      const documents = [{
+        field1: 'abc',
+        field2: 'bca',
+        field3: 'cba',
+        field4: 'cab',
+        field5: 'bac'
+      }];
+      try {
+        await getSchema(documents, { distinctFieldsAbortThreshold: 4 });
+        assert.fail('Analysis did not throw');
+      } catch (error) {
+        assert.strictEqual((error as Error).message, 'Schema analysis aborted: Fields count above 4');
+      }
+    });
   });
 });

--- a/test/bloated.test.ts
+++ b/test/bloated.test.ts
@@ -87,5 +87,27 @@ describe('bloated documents', function() {
         assert.strictEqual((error as Error).message, 'Schema analysis aborted: Fields count above 4');
       }
     });
+
+    it('does not count the same field in different documents', async function() {
+      const documents = [{
+        field1: {
+          field2: {
+            field3: 'abc'
+          }
+        }
+      }, {
+        field1: {
+          field2: {
+            field3: 'bca'
+          }
+        }
+      }];
+      try {
+        await getSchema(documents, { distinctFieldsAbortThreshold: 4 });
+        assert.ok('Analysis finished');
+      } catch (error) {
+        assert.fail('Analysis aborted unexpectedly');
+      }
+    });
   });
 });


### PR DESCRIPTION
Again an optional parameter. I had hard time coming up with the name, let me know if you have better suggestion. This one is a hard limit that can be imposed on the complexity (represented by unique field count). Together with the lower stored samples limit, it can be used as a prevention mechanism for running out of memory during the analysis itself (https://jira.mongodb.org/browse/COMPASS-8526), or later down the line (such as the new schema export conversion or file download).